### PR TITLE
Fix problem with umask error

### DIFF
--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -171,6 +171,7 @@ class SingularitySandbox:
                     "exec",
                     "--writable",
                     "--no-home",
+                    "--no-umask",
                     self.sandbox_dir,
                     *shlex.split(cmd),
                 ]


### PR DESCRIPTION
Changes the umask to the singularity default of 0022, which ensures that conda will always work.