### PR TITLE
Explicit Miniforge license acceptance

### DIFF
--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -77,15 +77,27 @@ class Build(CotainrSubcommand):
         Apptainer/Singularity <BUILD SPEC>.
     conda_env : :class:`os.PathLike`, optional
         Path to a Conda environment.yml file to install and activate in the
-        container.
+        container. When installing a Conda environment, you must accept the
+        Miniforge license terms, as specified during the build process.
     system : str
-        Which system/partition you will be running the container on, will set base
-        image and other parameters for a simpler container creation.
-        Running the info command will tell you more about the system and what is
-        available.
+        Which system/partition you will be running the container on. This sets
+        base image and other parameters for a simpler container creation.
+        Running the info command will tell you more about the system and what
+        is available.
+    accept_licenses : bool, default=False
+        Accept all license terms (if any) needed for completing the container
+        build process.
     """
 
-    def __init__(self, *, image_path, base_image=None, conda_env=None, system=None):
+    def __init__(
+        self,
+        *,
+        image_path,
+        base_image=None,
+        conda_env=None,
+        system=None,
+        accept_licenses=False,
+    ):
         """Construct the "build" subcommand."""
         self.image_path = Path(image_path).resolve()
         if self.image_path.exists():
@@ -96,6 +108,7 @@ class Build(CotainrSubcommand):
             if val != "y":
                 sys.exit(0)
 
+        self.accept_licenses = accept_licenses
         self.base_image = base_image
         systems = util.get_systems()
         if system is not None:
@@ -135,6 +148,13 @@ class Build(CotainrSubcommand):
             help=_extract_help_from_docstring(arg="conda_env", docstring=cls.__doc__),
             type=Path,
         )
+        parser.add_argument(
+            "--accept-licenses",
+            help=_extract_help_from_docstring(
+                arg="accept_licenses", docstring=cls.__doc__
+            ),
+            action="store_true",
+        )
 
     def execute(self):
         """Execute the "build" subcommand."""
@@ -144,7 +164,9 @@ class Build(CotainrSubcommand):
                 conda_env_name = "conda_container_env"
                 conda_env_file = sandbox.sandbox_dir / self.conda_env.name
                 shutil.copyfile(self.conda_env, conda_env_file)
-                conda_install = pack.CondaInstall(sandbox=sandbox)
+                conda_install = pack.CondaInstall(
+                    sandbox=sandbox, license_accepted=self.accept_licenses
+                )
                 conda_install.add_environment(path=conda_env_file, name=conda_env_name)
                 sandbox.add_to_env(shell_script=f"conda activate {conda_env_name}")
                 conda_install.cleanup_unused_files()
@@ -401,6 +423,13 @@ def _extract_help_from_docstring(*, arg, docstring):
     docstring : str
         The numpydoc docstring in which `arg` is documented.
 
+    Returns
+    -------
+    arg_description : str
+        The argument description formatted as as done in the default arguments
+        provided by an `argparse.ArgumentParser`, i.e. a single line, no
+        leading white space, first letter lower case, and no trailing period.
+
     Raises
     ------
     KeyError
@@ -412,7 +441,9 @@ def _extract_help_from_docstring(*, arg, docstring):
         if arg_found:
             if " : " in line or line.strip() == "":
                 # No more description lines, return the description
-                return "".join(arg_desc).strip().lower().rstrip(".")
+                arg_description = "".join(arg_desc).strip().rstrip(".")
+                arg_description = arg_description[0].lower() + arg_description[1:]
+                return arg_description
             else:
                 # Extract line as part of arg description
                 arg_desc.extend([line.strip(), " "])

--- a/cotainr/pack.py
+++ b/cotainr/pack.py
@@ -79,8 +79,8 @@ class CondaInstall:
             )
         else:
             print(
-                "You have accepted the Miniforge installer license via the command line "
-                "option '--accept-licenses'."
+                "You have accepted the Miniforge installer license via the command "
+                "line option '--accept-licenses'."
             )
 
         # Bootstrap Conda environment in container

--- a/cotainr/pack.py
+++ b/cotainr/pack.py
@@ -26,7 +26,11 @@ class CondaInstall:
     """
     A Conda installation in a container sandbox.
 
-    Bootstraps a miniforge based Conda installation in a container sandbox.
+    Bootstraps a Miniforge based Conda installation in a container sandbox. As
+    part of the bootstrapping of Miniforge, the user must accept the `Miniforge
+    license terms
+    <https://github.com/conda-forge/miniforge/blob/main/LICENSE>`_.
+
 
     Parameters
     ----------
@@ -34,6 +38,9 @@ class CondaInstall:
         The sandbox in which Conda should be installed.
     prefix : str
         The Conda prefix to use for the Conda install.
+    license_accepted : bool, default=False
+        The flag to indicate whether or not the user has already accepted the
+        Miniforge license terms.
 
     Attributes
     ----------
@@ -41,6 +48,16 @@ class CondaInstall:
         The sandbox in which Conda is installed.
     prefix : str
         The Conda prefix used for the Conda install.
+    license_accepted : bool
+        Whether or not the Miniforge license terms have been accepted.
+
+    Notes
+    -----
+    When adding a Conda environment, it is the responsibility of the user of
+    cotainr to make sure they have the necessary rights to use the Conda
+    channels/repositories and packages specified in the Conda environment, e.g.
+    if `using the default Anaconda repositories
+    <https://www.anaconda.com/blog/anaconda-commercial-edition-faq>`_.
     """
 
     def __init__(self, *, sandbox, prefix="/opt/conda", license_accepted=False):
@@ -53,14 +70,16 @@ class CondaInstall:
         conda_installer_path = (
             Path(self.sandbox.sandbox_dir).resolve() / "conda_installer.sh"
         )
-        self._download_conda_installer(path=conda_installer_path)
+        self._download_miniforge_installer(installer_path=conda_installer_path)
 
-        # Make sure the user has accepted the Conda installer license
+        # Make sure the user has accepted the Miniforge installer license
         if not license_accepted:
-            self._display_license_for_acceptance(installer_path=conda_installer_path)
+            self._display_miniforge_license_for_acceptance(
+                installer_path=conda_installer_path
+            )
         else:
             print(
-                "You have accepted the Conda installer license via the command line "
+                "You have accepted the Miniforge installer license via the command line "
                 "option '--accept-licenses'."
             )
 
@@ -136,29 +155,30 @@ class CondaInstall:
                 f"{source_check_process.stdout.strip()}. Aborting!"
             )
 
-    def _display_license_for_acceptance(self, *, installer_path):
+    def _display_miniforge_license_for_acceptance(self, *, installer_path):
         """
-        Extract and display Conda installer license for acceptance.
+        Extract and display Miniforge installer license for acceptance.
 
-        Runs the Conda installer to extract the license, displays it to the
-        user, and prompts for acceptance of the license terms. Exits if the
-        license terms are not accepted.
+        Runs the Miniforge bootstrap installer to extract the license, displays
+        it to the user, and prompts for acceptance of the license terms. Exits
+        if the license terms are not accepted.
 
         Parameters
         ----------
         installer_path : pathlib.Path
-            The path of the Conda installer to run to bootstrap Conda.
+            The path of the Miniforge installer to run to bootstrap Conda.
 
         Raises
         ------
         RuntimeError
-            If unable to extract a license from the Conda installer.
+            If unable to extract a license from the Miniforge installer.
 
         Notes
         -----
-        This assumes that the Conda installer, as it is run, prompts the user
-        for pressing ENTER to display the license, then displays the license
-        and prompts the user to answer "yes" to accept the license terms.
+        This assumes that the Miniforge installer, as it is run, prompts the
+        user for pressing ENTER to display the license, then displays the
+        license and prompts the user to answer "yes" to accept the license
+        terms.
 
         We try to "forward" this flow to the user by extracting the text shown
         when running the installer and pressing ENTER. We then prompt for a
@@ -185,26 +205,28 @@ class CondaInstall:
             print(license)
             val = input()  # prompt user for acceptance of license terms
             if val != "yes":
-                print("You have not accepted the Conda installer license. Aborting!")
+                print(
+                    "You have not accepted the Miniforge installer license. Aborting!"
+                )
                 sys.exit(0)
 
             self.license_accepted = True
-            print("You have accepted the Conda installer license.")
+            print("You have accepted the Miniforge installer license.")
         else:
             raise RuntimeError(
-                "No license seems to be displayed by the Conda installer."
+                "No license seems to be displayed by the Miniforge installer."
             )
 
-    def _download_conda_installer(self, *, path):
+    def _download_miniforge_installer(self, *, installer_path):
         """
-        Download the Conda installer to `path`.
+        Download the Miniforge installer to `path`.
 
         Parameters
         ----------
-        path : pathlib.Path
+        installer_path : pathlib.Path
             The path to download the conda installer to.
         """
-        conda_installer_url = (
+        miniforge_installer_url = (
             "https://github.com/conda-forge/miniforge/releases/latest/download/"
             "Miniforge3-Linux-x86_64.sh"
         )
@@ -212,8 +234,10 @@ class CondaInstall:
         # Make up to 3 attempts at downloading the installer
         for retry in range(3):
             try:
-                with urllib.request.urlopen(conda_installer_url) as url:  # nosec B310
-                    path.write_bytes(url.read())
+                with urllib.request.urlopen(
+                    miniforge_installer_url
+                ) as url:  # nosec B310
+                    installer_path.write_bytes(url.read())
 
                 break
 

--- a/cotainr/tests/cli/test_cli_utils.py
+++ b/cotainr/tests/cli/test_cli_utils.py
@@ -32,7 +32,7 @@ class TestExtractHelpFromDocstring:
         ):
             _extract_help_from_docstring(arg="some_arg", docstring=docstring)
 
-    def test_description_lower_case(self):
+    def test_description_first_letter_lower_case(self):
         docstring = """
         Parameters
         ----------
@@ -40,7 +40,7 @@ class TestExtractHelpFromDocstring:
             The INTEGER
         """
         help_msg = _extract_help_from_docstring(arg="some_arg", docstring=docstring)
-        assert help_msg == "the integer"
+        assert help_msg == "the INTEGER"
 
     def test_description_period_strip(self):
         docstring = """

--- a/cotainr/tests/pack/patches.py
+++ b/cotainr/tests/pack/patches.py
@@ -7,6 +7,8 @@ Licensed under the European Union Public License (EUPL) 1.2
 
 """
 
+import sys
+
 import pytest
 
 import cotainr.pack
@@ -29,6 +31,25 @@ def patch_disable_conda_install_bootstrap_conda(monkeypatch):
 
     monkeypatch.setattr(
         cotainr.pack.CondaInstall, "_bootstrap_conda", mock_bootstrap_conda
+    )
+
+
+@pytest.fixture
+def patch_disable_conda_install_display_miniforge_license_for_acceptance(monkeypatch):
+    """
+    Disable CondaInstall._display_miniforge_license_for_acceptance(...).
+
+    The explicit request for an acceptance of the Miniforge license terms is
+    replaced by a mock exits with a message about what would have happened.
+    """
+
+    def mock_display_miniforge_license_for_acceptance(self, *, installer_path):
+        sys.exit("PATCH: Showing license terms for {installer_path}")
+
+    monkeypatch.setattr(
+        cotainr.pack.CondaInstall,
+        "_display_miniforge_license_for_acceptance",
+        mock_display_miniforge_license_for_acceptance,
     )
 
 

--- a/cotainr/tests/pack/patches.py
+++ b/cotainr/tests/pack/patches.py
@@ -33,21 +33,21 @@ def patch_disable_conda_install_bootstrap_conda(monkeypatch):
 
 
 @pytest.fixture
-def patch_disable_conda_install_download_conda_installer(monkeypatch):
+def patch_disable_conda_install_download_miniforge_installer(monkeypatch):
     """
-    Disable CondaInstall._download_conda_installer(...).
+    Disable CondaInstall._download_minforge_installer(...).
 
     The installer download is replaced by a method that, in place of the
     installer, creates a file containing a line saying that this is where the
     installer would have been downloaded to.
     """
 
-    def mock_download_conda_installer(self, *, path):
-        path.write_text("Conda installer downloaded to this file")
-        assert path.exists()
+    def mock_download_miniforge_installer(self, *, installer_path):
+        installer_path.write_text("Miniforge installer downloaded to this file")
+        assert installer_path.exists()
 
     monkeypatch.setattr(
         cotainr.pack.CondaInstall,
-        "_download_conda_installer",
-        mock_download_conda_installer,
+        "_download_miniforge_installer",
+        mock_download_miniforge_installer,
     )

--- a/cotainr/tests/pack/stubs.py
+++ b/cotainr/tests/pack/stubs.py
@@ -1,0 +1,41 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+
+from abc import ABC
+
+
+class StubLicensePopen(ABC):
+    def __init__(self, args, stdin=None, stdout=None, text=None):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    def communicate(self, input=None):
+        print(f"{self.__class__.__name__} received: {input=}.")
+        return (self.license_text, "")
+
+    def kill(self):
+        print(f"{self.__class__.__name__} killed.")
+
+
+class StubEmptyLicensePopen(StubLicensePopen):
+    license_text = ""
+
+
+class StubShowLicensePopen(StubLicensePopen):
+    license_text = (
+        "STUB:\n"
+        "Please, press ENTER to continue\n"
+        ">>> \n"
+        "This is the license terms..."
+    )

--- a/cotainr/tests/pack/test_conda_install.py
+++ b/cotainr/tests/pack/test_conda_install.py
@@ -35,6 +35,31 @@ class TestConstructor:
         assert conda_install.prefix == "/opt/conda"
         assert conda_install.license_accepted
 
+    def test_beforehand_license_acceptance(
+        self,
+        patch_disable_conda_install_bootstrap_conda,
+        patch_disable_conda_install_download_miniforge_installer,
+        patch_disable_singularity_sandbox_subprocess_runner,
+        capsys,
+    ):
+        with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
+            CondaInstall(sandbox=sandbox, license_accepted=True)
+
+        # Check that the message about accepting Miniforge license on
+        # beforehand is shown
+        (
+            _sandbox_create_cmd,
+            miniforge_license_accept_cmd,
+            _conda_bootstrap_cmd,
+            _conda_bootstrap_clean_cmd,
+        ) = (
+            capsys.readouterr().out.strip().split("\n")
+        )
+        assert miniforge_license_accept_cmd == (
+            "You have accepted the Miniforge installer license via the command line option "
+            "'--accept-licenses'."
+        )
+
     def test_cleanup(
         self,
         capsys,
@@ -174,6 +199,26 @@ class Test_CheckCondaBootstrapIntegrity:
         )
         assert exc_msg.endswith("Aborting!")
         assert "'conda', 'info', '--base'" in exc_msg
+
+
+class Test_DisplayMiniforgeLicenseForAcceptance:
+    def test_acccepting_license(self):
+        1 / 0
+
+    def test_not_accepting_license(self):
+        1 / 0
+
+    def test_installer_not_showing_license(self):
+        1 / 0
+
+    def test_press_ENTER(self):
+        1 / 0
+
+    def test_print_license(self):
+        1 / 0
+
+    def test_replace_prompt_for_error(self):
+        1 / 0
 
 
 class Test_DownloadCondaInstaller:

--- a/cotainr/tests/test_end_to_end.py
+++ b/cotainr/tests/test_end_to_end.py
@@ -29,7 +29,8 @@ def test_conda_env_build(
         args=shlex.split(
             f"build {build_container_path} "
             f"--base-image={data_cached_ubuntu_sif} "
-            f"--conda-env={conda_env_path}"
+            f"--conda-env={conda_env_path} "
+            "--accept-licenses"
         )
     ).subcommand.execute()
 

--- a/doc/user_guide/conda_env.rst
+++ b/doc/user_guide/conda_env.rst
@@ -4,6 +4,11 @@ Conda Environments
 ==================
 Adding a `conda environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_ to a container may be easily done using `cotainr`.
 
+.. admonition:: Make sure you have the rights to use the packages in your conda environment
+    :class: warning
+
+    When adding a conda environment, it is the responsibility of the user of `cotainr` to make sure they have the necessary rights to use the conda channels/repositories and packages specified in the conda environment, e.g. if `using the default Anaconda repositories <https://www.anaconda.com/blog/anaconda-commercial-edition-faq>`_.
+
 As an example, consider the following `conda environment file <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#sharing-an-environment>`_, `my_conda_env.yml`:
 
 .. admonition:: Base image requirement
@@ -35,6 +40,11 @@ The conda environment is automatically activated when the container is run, allo
     $ singularity exec my_conda_env_container.sif python3 -c "import numpy; print(numpy.__version__)"
     1.23.5
 
+.. admonition:: You must accept the Miniforge license to add a conda environment
+  :class: note
+
+  Bootstrapping of the conda environment in the container is done using `Miniforge <https://github.com/conda-forge/miniforge>`_. As part of the bootstrap process, you must accept the `Miniforge license terms <https://github.com/conda-forge/miniforge/blob/main/LICENSE>`_. This can be done either by accepting them during the container build process, or by specifying the :code:`--accept-licenses` option when invoking :code:`cotainr build`.
+
 
 Pip packages
 ------------
@@ -48,6 +58,7 @@ Pip packages
     dependencies:
       - python=3.11.0
       - numpy=1.23.5
+      - pip
       - pip:
         - scipy==1.9.3
 


### PR DESCRIPTION
This PR makes it more explicit that the user has to accept the [Miniforge license terms](https://github.com/conda-forge/miniforge/blob/main/LICENSE) when using `--conda-env` with `cotainr build` as we use Miniforge to bootstrap the conda environment in the container. This PR includes:

- A change to `cotainr build --conda-env ...` that now extracts the Miniforge license from the installer and asks the user to explicitly answer "yes" to accepting the license terms.
- The introduction of the `--accept-licenses` option to `cotainr build` that, when specified, assumes acceptance of all licenses (if any) - to be used in silent background builds where user interaction is not possible.
- An update to the documentation more clearly stating that the user has to accept the Miniforge license terms and has the responsibility of making sure that they have the rights to use the channels/repositories and packages, they specify in their conda environment.
- A refactoring/clean-up around the terminology "conda installer" vs "miniforge installer" to make it more explicit that we use Miniforge.
- A few minor clean-ups related to how CLI options are displayed in help messages.