### PR TITLE
Much import output formatting

### DIFF
--- a/cotainr/__init__.py
+++ b/cotainr/__init__.py
@@ -22,12 +22,12 @@ _minimum_dependency_version = {
 if sys.version_info < _minimum_dependency_version["python"]:
     sys.exit(
         (
-            "\033[91m"  # start of red colored text
+            "\x1b[38;5;160m"  # start of red colored text
             "Cotainr requires Python>=%s\n"
             "You are running Python==%s\n"
             "from '%s'\n"
             "ABORTING!"
-            "\033[0m"  # end of red colored text
+            "\x1b[0m"  # end of red colored text
         )
         % (
             ".".join(map(str, _minimum_dependency_version["python"])),

--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -86,11 +86,18 @@ class Build(CotainrSubcommand):
         Path to a Conda environment.yml file to install and activate in the
         container.
     system : str
-        Which system/partition you will be running the container on, will set base
-        image and other parameters for a simpler container creation.
-        Running the info command will tell you more about the system and what is
-        available.
-    TODO: Cleanup and document
+        Which system/partition you will be running the container on, will set
+        base image and other parameters for a simpler container creation.
+        Running the info command will tell you more about the system and what
+        is available.
+    verbosity : int, optional
+        The verbosity of the output from cotainr: -1 for only CRITICAL, 0 (the
+        default) for cotainr INFO and subprocess WARNING, 1 for subprocess
+        output as well, 2 for subprocess INFO, 3 for DEBUG, and 4 for TRACE.
+    log_to_file : bool
+        Create files containing all logging information shown on stdout/stderr.
+    no_color : bool
+        Do not use colored console output.
     """
 
     def __init__(
@@ -100,7 +107,7 @@ class Build(CotainrSubcommand):
         base_image=None,
         conda_env=None,
         system=None,
-        verbosity,
+        verbosity=0,
         log_to_file,
         no_color,
     ):
@@ -170,8 +177,9 @@ class Build(CotainrSubcommand):
             default=0,
             help=(
                 "increase the verbosity of the output from cotainr. "
-                "Can be used multiple times: Once for subprocess output, twice for INFO, "
-                "three times for DEBUG, and four times for TRACE."  # TODO extract from docstring
+                "Can be used multiple times: Once for subprocess output, "
+                "twice for subprocess INFO, three times for DEBUG, "
+                "and four times for TRACE"
             ),
         )
         verbose_quiet_group.add_argument(
@@ -180,20 +188,17 @@ class Build(CotainrSubcommand):
             action="store_const",
             const=-1,
             dest="verbosity",
-            help="do not show any non-CRITICAL output from cotainr.",  # TODO extract from docstring
+            help="do not show any non-CRITICAL output from cotainr",
         )
         parser.add_argument(
             "--log-to-file",
             action="store_true",
-            help=(
-                "create files containing all logging "
-                "information shown on stdout/stderr."  # TODO extract from docstring
-            ),
+            help=_extract_help_from_docstring(arg="log_to_file", docstring=cls.__doc__),
         )
         parser.add_argument(
             "--no-color",
             action="store_true",
-            help="avoid coloring console output.",  # TODO extract from docstring
+            help=_extract_help_from_docstring(arg="no_color", docstring=cls.__doc__),
         )
 
     def execute(self):
@@ -253,8 +258,8 @@ class Info(CotainrSubcommand):
 
     def __init__(self):
         """Construct the "info" subcommand."""
-        self._checkmark = "\033[92mOK\033[0m"  # green OK
-        self._nocheckmark = "\033[91mERROR\033[0m"  # red ERROR
+        self._checkmark = "\x1b[38;5;2mOK\x1b[0m"  # green OK
+        self._nocheckmark = "\xb1[38;5;1mERROR\x1b[0m"  # red ERROR
         self._tabs_width = 4
 
     def execute(self):
@@ -470,8 +475,6 @@ class CotainrCLI:
         try:
             self.subcommand = self.args.subcommand_cls(**subcommand_args)
         except AttributeError:
-            # TODO: Add proper exception logs throughout (and not here...)
-            logger.exception("EXCEPTION: running subcommand")
             # Print help and exit if no subcommand was given
             self.subcommand = _NoSubcommand(parser=parser)
 

--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -108,8 +108,8 @@ class Build(CotainrSubcommand):
         conda_env=None,
         system=None,
         verbosity=0,
-        log_to_file,
-        no_color,
+        log_to_file=False,
+        no_color=False,
     ):
         """Construct the "build" subcommand."""
         self.log_settings = tracing.LogSettings(

--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -531,7 +531,7 @@ class CotainrCLI:
             )
             cotainr_stderr_fmt = cotainr_stdout_fmt
         else:
-            if log_settings.verbosity == -1:
+            if log_settings.verbosity <= -1:
                 cotainr_log_level = logging.CRITICAL
             else:
                 cotainr_log_level = logging.INFO

--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -11,12 +11,12 @@ Classes
 -------
 CotainrSubcommand(ABC)
     Abstract base class for `CotainrCLI` subcommands.
-Build
+Build(CotainrSubcommand)
     Build a container. (The "build" subcommand.)
 CotainrCLI
     Build Apptainer/Singularity containers for HPC systems in user space. (The
     main CLI command.)
-Info
+Info(CotainrSubcommand)
     Obtain info about the state of all required dependencies for building a
     container. (The "info" subcommand.)
 

--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -543,10 +543,18 @@ class CotainrCLI:
         cotainr_stderr_handlers = [logging.StreamHandler(stream=sys.stderr)]
         if log_settings.log_file_path is not None:
             cotainr_stdout_handlers.append(
-                logging.FileHandler(log_settings.log_file_path.with_suffix(".out"))
+                logging.FileHandler(
+                    log_settings.log_file_path.with_suffix(
+                        log_settings.log_file_path.suffix + ".out"
+                    )
+                )
             )
             cotainr_stderr_handlers.append(
-                logging.FileHandler(log_settings.log_file_path.with_suffix(".err"))
+                logging.FileHandler(
+                    log_settings.log_file_path.with_suffix(
+                        log_settings.log_file_path.suffix + ".err"
+                    )
+                )
             )
 
         for stdout_handler in cotainr_stdout_handlers:

--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -270,7 +270,7 @@ class Info(CotainrSubcommand):
     def __init__(self):
         """Construct the "info" subcommand."""
         self._checkmark = "\x1b[38;5;2mOK\x1b[0m"  # green OK
-        self._nocheckmark = "\xb1[38;5;1mERROR\x1b[0m"  # red ERROR
+        self._nocheckmark = "\x1b[38;5;1mERROR\x1b[0m"  # red ERROR
         self._tabs_width = 4
 
     def execute(self):

--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -485,8 +485,26 @@ class CotainrCLI:
         )
 
     def _setup_cotainr_cli_logging(self, *, log_settings):
-        # TODO: document
+        """
+        Setup logging for the cotainr main CLI.
+
+        Setting up the logging for the cotainr main CLI includes:
+        - Defining log levels based on CLI verbosity arguments.
+        - Defining log message formats based on CLI verbosity arguments.
+        - Creating log handlers for console output.
+        - Creating log handlers for log file output, if requested.
+        - Setting up colored console output, if requested.
+        - Defining the cotainr "root logger".
+
+        Parameters
+        ----------
+        log_settings : :class:`~cotainr.tracing.LogSettings`
+            The log settings to use for the cotainr main CLI logging.
+        """
+
         class OnlyDebugInfoLevelFilter(logging.Filter):
+            """A simple logging filter that removes records >=INFO."""
+
             def filter(self, record):
                 return record.levelno <= logging.INFO
 

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -53,18 +53,20 @@ class SingularitySandbox:
         sandbox context, otherwise it is None.
     """
 
-    def __init__(self, *, base_image, verbosity, log_file_path=None, no_color=False):
+    def __init__(self, *, base_image, log_settings=None):
         """Construct the SingularitySandbox context manager."""
         self.base_image = base_image
         self.sandbox_dir = None
-        self.verbosity = verbosity
-        self.log_dispatcher = tracing.LogDispatcher(
-            name=__class__.__name__,
-            map_log_level_func=self._map_log_level,
-            verbosity=verbosity,
-            log_file_path=log_file_path,
-            no_color=no_color,
-        )
+        if log_settings is not None:
+            self.verbosity = log_settings.verbosity
+            self.log_dispatcher = tracing.LogDispatcher(
+                name=__class__.__name__,
+                map_log_level_func=self._map_log_level,
+                log_settings=log_settings,
+            )
+        else:
+            self.verbosity = 0
+            self.log_dispatcher = None
 
     def __enter__(self):
         """

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -55,7 +55,7 @@ class SingularitySandbox:
     #TODO: Cleanup and document
     """
 
-    def __init__(self, *, base_image, verbosity):
+    def __init__(self, *, base_image, verbosity, log_file_prefix=None):
         """Construct the SingularitySandbox context manager."""
         self.base_image = base_image
         self.sandbox_dir = None
@@ -64,6 +64,7 @@ class SingularitySandbox:
             name=__class__.__name__,
             map_log_level_func=self._map_log_level,
             verbosity=verbosity,
+            log_file_prefix=log_file_prefix,
         )
 
     def __enter__(self):

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -86,6 +86,7 @@ class SingularitySandbox:
             args=self._add_output_formatting_args(
                 args=[
                     "singularity",
+                    "--nocolor",
                     "build",
                     "--force",  # sandbox_dir.mkdir() checks for existing sandbox image
                     "--sandbox",
@@ -172,6 +173,7 @@ class SingularitySandbox:
             args=self._add_output_formatting_args(
                 args=[
                     "singularity",
+                    "--nocolor",
                     "build",
                     "--force",
                     path,
@@ -227,6 +229,7 @@ class SingularitySandbox:
                 args=self._add_output_formatting_args(
                     args=[
                         "singularity",
+                        "--nocolor",
                         "exec",
                         "--writable",
                         "--no-home",
@@ -284,7 +287,7 @@ class SingularitySandbox:
             return logging.WARNING
         elif msg.startswith("ERROR"):
             return logging.ERROR
-        elif msg.startswith("ABRT"):
+        elif msg.startswith("ABRT") or msg.startswith("FATAL"):
             return logging.CRITICAL
         else:
             # If no prefix on message, assume its INFO level

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -23,9 +23,10 @@ import sys
 from tempfile import TemporaryDirectory
 
 from . import __version__ as _cotainr_version
+from . import tracing
 from . import util
 
-#TODO: Add loggers all over
+# TODO: Add loggers all over
 logger = logging.getLogger(__name__)
 
 
@@ -54,12 +55,14 @@ class SingularitySandbox:
     #TODO: Cleanup and document
     """
 
-    def __init__(self, *, base_image, log_dispatcher_factory=None):
+    def __init__(self, *, base_image, verbosity):
         """Construct the SingularitySandbox context manager."""
         self.base_image = base_image
-        self.log_dispatcher = log_dispatcher_factory(
-            name=__class__.__name__, map_log_level_func=self._map_log_level
-        ) #TODO: Consider replacing __class__.__name__ with actual singularity provider
+        self.log_dispatcher = tracing.LogDispatcher(
+            name=__class__.__name__,
+            map_log_level_func=self._map_log_level,
+            verbosity=verbosity,
+        )  # TODO: Consider replacing __class__.__name__ with actual singularity provider
         self.sandbox_dir = None
 
     def __enter__(self):
@@ -248,7 +251,7 @@ class SingularitySandbox:
 
     @staticmethod
     def _map_log_level(msg):
-        #TODO: Cleanup and document
+        # TODO: Cleanup and document
         if msg.startswith("DEBUG") or msg.startswith("VERBOSE"):
             return logging.DEBUG
         elif msg.startswith("INFO") or msg.startswith("LOG"):

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -54,9 +54,10 @@ class SingularitySandbox:
     sandbox_dir : :class:`os.PathLike` or None
         The path to the temporary directory containing the sandbox if within a
         sandbox context, otherwise it is None.
-    log_dispatcher : :class:`~cotainr.tracing.LogDispatcher`.
+    log_dispatcher : :class:`~cotainr.tracing.LogDispatcher` or None.
         The log dispatcher used to process stdout/stderr message from
-        Singularity commands that run in sandbox.
+        Singularity commands that run in sandbox, if the logging machinery is
+        used.
     """
 
     def __init__(self, *, base_image, log_settings=None):
@@ -134,6 +135,8 @@ class SingularitySandbox:
         file.
 
         """
+        self._assert_within_sandbox_context()
+
         labels_path = self.sandbox_dir / ".singularity.d/labels.json"
         with open(labels_path, "r+") as f:
             metadata = json.load(f)

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -55,7 +55,7 @@ class SingularitySandbox:
     #TODO: Cleanup and document
     """
 
-    def __init__(self, *, base_image, verbosity, log_file_prefix=None):
+    def __init__(self, *, base_image, verbosity, log_file_path=None):
         """Construct the SingularitySandbox context manager."""
         self.base_image = base_image
         self.sandbox_dir = None
@@ -64,7 +64,7 @@ class SingularitySandbox:
             name=__class__.__name__,
             map_log_level_func=self._map_log_level,
             verbosity=verbosity,
-            log_file_prefix=log_file_prefix,
+            log_file_path=log_file_path,
         )
 
     def __enter__(self):
@@ -183,7 +183,7 @@ class SingularitySandbox:
             ),
         )
 
-    def run_command_in_container(self, *, custom_log_dispatcher=None, cmd):
+    def run_command_in_container(self, *, cmd, custom_log_dispatcher=None):
         """
         Run a command in the container sandbox.
 

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -26,7 +26,6 @@ from . import __version__ as _cotainr_version
 from . import tracing
 from . import util
 
-# TODO: Add loggers all over
 logger = logging.getLogger(__name__)
 
 
@@ -52,7 +51,6 @@ class SingularitySandbox:
     sandbox_dir : :class:`os.PathLike` or None
         The path to the temporary directory containing the sandbox if within a
         sandbox context, otherwise it is None.
-    #TODO: Cleanup and document
     """
 
     def __init__(self, *, base_image, verbosity, log_file_path=None, no_color=False):
@@ -85,7 +83,7 @@ class SingularitySandbox:
         self.sandbox_dir = Path(self._tmp_dir.name) / "singularity_sandbox"
         self.sandbox_dir.mkdir(exist_ok=False)
         self._subprocess_runner(
-            args=self._add_output_formatting_args(
+            args=self._add_verbosity_arg(
                 args=[
                     "singularity",
                     "--nocolor",
@@ -172,7 +170,7 @@ class SingularitySandbox:
         self._assert_within_sandbox_context()
 
         self._subprocess_runner(
-            args=self._add_output_formatting_args(
+            args=self._add_verbosity_arg(
                 args=[
                     "singularity",
                     "--nocolor",
@@ -196,7 +194,6 @@ class SingularitySandbox:
         ----------
         cmd : str
             The command to run in the container sandbox.
-        TODO: Update
 
         Returns
         -------
@@ -228,7 +225,7 @@ class SingularitySandbox:
         try:
             process = self._subprocess_runner(
                 custom_log_dispatcher=custom_log_dispatcher,
-                args=self._add_output_formatting_args(
+                args=self._add_verbosity_arg(
                     args=[
                         "singularity",
                         "--nocolor",
@@ -257,11 +254,11 @@ class SingularitySandbox:
         if self.sandbox_dir is None:
             raise ValueError("The operation is only valid inside a sandbox context.")
 
-    def _add_output_formatting_args(self, *, args):
-        # TODO: document
+    def _add_verbosity_arg(self, *, args):
         if self.verbosity <= 0:
             args.insert(1, "--quiet")
-        elif self.verbosity >= 2:
+        elif self.verbosity >= 3:
+            # Assume --verbose is a debug level
             args.insert(1, "--verbose")
 
         return args
@@ -282,7 +279,6 @@ class SingularitySandbox:
 
     @staticmethod
     def _map_log_level(msg):
-        # TODO: Cleanup and document
         if msg.startswith("DEBUG") or msg.startswith("VERBOSE"):
             return logging.DEBUG
         elif msg.startswith("INFO") or msg.startswith("LOG"):

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -55,7 +55,7 @@ class SingularitySandbox:
     #TODO: Cleanup and document
     """
 
-    def __init__(self, *, base_image, verbosity, console_log_msg_queue):
+    def __init__(self, *, base_image, verbosity):
         """Construct the SingularitySandbox context manager."""
         self.base_image = base_image
         self.sandbox_dir = None
@@ -64,7 +64,6 @@ class SingularitySandbox:
             name=__class__.__name__,
             map_log_level_func=self._map_log_level,
             verbosity=verbosity,
-            console_log_msg_queue=console_log_msg_queue
         )
 
     def __enter__(self):

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -55,7 +55,7 @@ class SingularitySandbox:
     #TODO: Cleanup and document
     """
 
-    def __init__(self, *, base_image, verbosity):
+    def __init__(self, *, base_image, verbosity, console_log_msg_queue):
         """Construct the SingularitySandbox context manager."""
         self.base_image = base_image
         self.sandbox_dir = None
@@ -64,6 +64,7 @@ class SingularitySandbox:
             name=__class__.__name__,
             map_log_level_func=self._map_log_level,
             verbosity=verbosity,
+            console_log_msg_queue=console_log_msg_queue
         )
 
     def __enter__(self):

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -267,15 +267,17 @@ class SingularitySandbox:
 
     def _subprocess_runner(self, *, custom_log_dispatcher=None, args, **kwargs):
         """Wrap the choice of subprocess runner."""
-        return util.stream_subprocess(
-            log_dispatcher=(
-                self.log_dispatcher
-                if custom_log_dispatcher is None
-                else custom_log_dispatcher
-            ),
-            args=args,
-            **kwargs,
-        )
+        if custom_log_dispatcher is not None:
+            with custom_log_dispatcher.prefix_stderr_name(
+                prefix=self.__class__.__name__
+            ):
+                return util.stream_subprocess(
+                    log_dispatcher=custom_log_dispatcher, args=args, **kwargs
+                )
+        else:
+            return util.stream_subprocess(
+                log_dispatcher=self.log_dispatcher, args=args, **kwargs
+            )
 
     @staticmethod
     def _map_log_level(msg):

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -55,7 +55,7 @@ class SingularitySandbox:
     #TODO: Cleanup and document
     """
 
-    def __init__(self, *, base_image, verbosity, log_file_path=None):
+    def __init__(self, *, base_image, verbosity, log_file_path=None, no_color=False):
         """Construct the SingularitySandbox context manager."""
         self.base_image = base_image
         self.sandbox_dir = None
@@ -65,6 +65,7 @@ class SingularitySandbox:
             map_log_level_func=self._map_log_level,
             verbosity=verbosity,
             log_file_path=log_file_path,
+            no_color=no_color,
         )
 
     def __enter__(self):

--- a/cotainr/pack.py
+++ b/cotainr/pack.py
@@ -192,10 +192,13 @@ class CondaInstall:
         if self.verbosity <= 0:
             return " -q"
         elif self.verbosity == 2:
+            # Conda INFO
             return " -v"
         elif self.verbosity == 3:
+            # Conda DEBUG
             return " -vv"
         elif self.verbosity >= 4:
+            # Conda TRACE
             return " -vvv"
         else:
             return ""

--- a/cotainr/pack.py
+++ b/cotainr/pack.py
@@ -52,7 +52,7 @@ class CondaInstall:
         self.sandbox = sandbox
         self.prefix = prefix
         if log_settings is not None:
-            self.verbosity = log_settings.verbosity
+            self._verbosity = log_settings.verbosity
             self.log_dispatcher = tracing.LogDispatcher(
                 name=__class__.__name__,
                 map_log_level_func=self._map_log_level,
@@ -60,7 +60,7 @@ class CondaInstall:
                 log_settings=log_settings,
             )
         else:
-            self.verbosity = 0
+            self._verbosity = 0
             self.log_dispatcher = None
 
         # Download Conda installer
@@ -183,15 +183,22 @@ class CondaInstall:
 
     @property
     def _conda_verbosity_arg(self):
-        if self.verbosity <= 0:
+        """
+        Add a verbosity level to Conda commands.
+
+        A mapping of the internal cotainr verbosity level to `Conda verbosity
+        flags
+        <https://docs.conda.io/projects/conda/en/latest/commands/create.html#Output,%20Prompt,%20and%20Flow%20Control%20Options>`_.
+        """
+        if self._verbosity <= 0:
             return " -q"
-        elif self.verbosity == 2:
+        elif self._verbosity == 2:
             # Conda INFO
             return " -v"
-        elif self.verbosity == 3:
+        elif self._verbosity == 3:
             # Conda DEBUG
             return " -vv"
-        elif self.verbosity >= 4:
+        elif self._verbosity >= 4:
             # Conda TRACE
             return " -vvv"
         else:

--- a/cotainr/pack.py
+++ b/cotainr/pack.py
@@ -47,7 +47,15 @@ class CondaInstall:
         The Conda prefix used for the Conda install.
     """
 
-    def __init__(self, *, sandbox, prefix="/opt/conda", verbosity, log_file_path=None):
+    def __init__(
+        self,
+        *,
+        sandbox,
+        prefix="/opt/conda",
+        verbosity,
+        log_file_path=None,
+        no_color=False,
+    ):
         """Bootstrap a conda installation."""
         self.sandbox = sandbox
         self.prefix = prefix
@@ -57,6 +65,7 @@ class CondaInstall:
             map_log_level_func=self._map_log_level,
             verbosity=verbosity,
             log_file_path=log_file_path,
+            no_color=no_color,
             filters=self._logging_filters,
         )
 

--- a/cotainr/pack.py
+++ b/cotainr/pack.py
@@ -190,9 +190,12 @@ class CondaInstall:
         """
         Display a message to the user.
 
-        Displays the message using the logging machinery if `log_level` is not
-        `None` and a `log_dispatcher` is defined for the `CondaInstall`,
-        otherwise uses `print`.
+        Displays the message using the `log_dispatcher` if `log_level` is not
+        `None` and a `log_dispatcher` is defined for the `CondaInstall`.
+        Otherwise prints the message on stdout. When the `log_dispatcher` is
+        used, messages with `log_levels` of WARNING or above are sent to stderr
+        whereas massages with with `log_level` below WARNING are sent to
+        stdout.
 
         Parameters
         ----------
@@ -205,7 +208,10 @@ class CondaInstall:
         if self.log_dispatcher is None or log_level is None:
             print(msg)
         else:
-            logger.log(level=log_level, msg=msg)
+            if log_level >= logging.WARNING:
+                self.log_dispatcher.logger_stderr.log(level=log_level, msg=msg)
+            else:
+                self.log_dispatcher.logger_stdout.log(level=log_level, msg=msg)
 
     def _display_miniforge_license_for_acceptance(self, *, installer_path):
         """

--- a/cotainr/pack.py
+++ b/cotainr/pack.py
@@ -399,7 +399,7 @@ class CondaInstall:
             """
 
             def filter(self, record):
-                return record.msg != ""
+                return record.msg.strip() != ""
 
         class OnlyFinalProgressbarFilter(logging.Filter):
             """
@@ -417,11 +417,12 @@ class CondaInstall:
                 return not self.progress_bar_re.match(record.msg)
 
         logging_filters = [
-            # The order matters as filters are applied in order.
-            # ANSI escape codes must be removed before filtering empty lines.
+            # The order matters as filters are applied in order. ANSI escape
+            # codes and partial progress bars must be removed before filtering
+            # empty lines.
             StripANSIEscapeCodes(),
-            NoEmptyLinesFilter(),
             OnlyFinalProgressbarFilter(),
+            NoEmptyLinesFilter(),
         ]
 
         return logging_filters

--- a/cotainr/tests/cli/data.py
+++ b/cotainr/tests/cli/data.py
@@ -1,0 +1,32 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+
+import pytest
+
+
+@pytest.fixture
+def data_cotainr_info_color_log_messages(data_log_level_names_mapping):
+    """"""
+    # log messages
+    log_level_msgs = {
+        level: f"Log {level_name} 6021"
+        for level, level_name in data_log_level_names_mapping.items()
+    }
+
+    # stdout
+    stdout_msgs = ["Cotainr:-: Log INFO 6021"]
+
+    # stderr
+    stderr_msgs = [
+        "Cotainr:-:CRITICAL: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
+        "Cotainr:-:ERROR: \x1b[38;5;1mLog ERROR 6021\x1b[0m",
+        "Cotainr:-:WARNING: \x1b[38;5;3mLog WARNING 6021\x1b[0m",
+    ]
+
+    return log_level_msgs, stdout_msgs, stderr_msgs

--- a/cotainr/tests/cli/data.py
+++ b/cotainr/tests/cli/data.py
@@ -22,10 +22,10 @@ def data_cotainr_critical_color_log_messages(data_log_level_names_mapping):
         for level, level_name in data_log_level_names_mapping.items()
     }
 
-    # Expected ending of stdout messages
+    # Expected stdout messages
     stdout_msgs = [""]
 
-    # Expected ending of stderr messages
+    # Expected stderr messages
     stderr_msgs = [
         "Cotainr:-:CRITICAL: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
     ]
@@ -46,12 +46,14 @@ def data_cotainr_debug_color_log_messages(data_log_level_names_mapping):
     }
 
     # Expected ending of stdout messages
+    # (debug messages are prepended with a time stamp)
     stdout_msgs = [
         "Cotainr:-:INFO: Log INFO 6021",
         "Cotainr:-:DEBUG: \x1b[38;5;8mLog DEBUG 6021\x1b[0m",
     ]
 
     # Expected ending of stderr messages
+    # (debug messages are prepended with a time stamp)
     stderr_msgs = [
         "Cotainr:-:CRITICAL: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
         "Cotainr:-:ERROR: \x1b[38;5;1mLog ERROR 6021\x1b[0m",

--- a/cotainr/tests/cli/data.py
+++ b/cotainr/tests/cli/data.py
@@ -11,22 +11,102 @@ import pytest
 
 
 @pytest.fixture
-def data_cotainr_info_color_log_messages(data_log_level_names_mapping):
-    """"""
-    # log messages
+def data_cotainr_critical_color_log_messages(data_log_level_names_mapping):
+    """
+    Log messages for standard log levels and their expected output to
+    stdout/stderr for the CotainrCLI logging machinery at CRITICAL level.
+    """
+    # Messages to log at the different standard log levels
     log_level_msgs = {
         level: f"Log {level_name} 6021"
         for level, level_name in data_log_level_names_mapping.items()
     }
 
-    # stdout
-    stdout_msgs = ["Cotainr:-: Log INFO 6021"]
+    # Expected ending of stdout messages
+    stdout_msgs = [""]
 
-    # stderr
+    # Expected ending of stderr messages
+    stderr_msgs = [
+        "Cotainr:-:CRITICAL: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
+    ]
+
+    return log_level_msgs, stdout_msgs, stderr_msgs
+
+
+@pytest.fixture
+def data_cotainr_debug_color_log_messages(data_log_level_names_mapping):
+    """
+    Log messages for standard log levels and their expected output to
+    stdout/stderr for the CotainrCLI logging machinery at DEBUG level.
+    """
+    # Messages to log at the different standard log levels
+    log_level_msgs = {
+        level: f"Log {level_name} 6021"
+        for level, level_name in data_log_level_names_mapping.items()
+    }
+
+    # Expected ending of stdout messages
+    stdout_msgs = [
+        "Cotainr:-:INFO: Log INFO 6021",
+        "Cotainr:-:DEBUG: \x1b[38;5;8mLog DEBUG 6021\x1b[0m",
+    ]
+
+    # Expected ending of stderr messages
     stderr_msgs = [
         "Cotainr:-:CRITICAL: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
         "Cotainr:-:ERROR: \x1b[38;5;1mLog ERROR 6021\x1b[0m",
         "Cotainr:-:WARNING: \x1b[38;5;3mLog WARNING 6021\x1b[0m",
+    ]
+
+    return log_level_msgs, stdout_msgs, stderr_msgs
+
+
+@pytest.fixture
+def data_cotainr_info_color_log_messages(data_log_level_names_mapping):
+    """
+    Log messages for standard log levels and their expected output to
+    stdout/stderr for the CotainrCLI logging machinery at INFO level.
+    """
+    # Messages to log at the different standard log levels
+    log_level_msgs = {
+        level: f"Log {level_name} 6021"
+        for level, level_name in data_log_level_names_mapping.items()
+    }
+
+    # Expected stdout messages
+    stdout_msgs = ["Cotainr:-: Log INFO 6021"]
+
+    # Expected stderr messages
+    stderr_msgs = [
+        "Cotainr:-:CRITICAL: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
+        "Cotainr:-:ERROR: \x1b[38;5;1mLog ERROR 6021\x1b[0m",
+        "Cotainr:-:WARNING: \x1b[38;5;3mLog WARNING 6021\x1b[0m",
+    ]
+
+    return log_level_msgs, stdout_msgs, stderr_msgs
+
+
+@pytest.fixture
+def data_cotainr_info_no_color_log_messages(data_log_level_names_mapping):
+    """
+    Log messages for standard log levels and their expected output to
+    stdout/stderr for the CotainrCLI logging machinery at INFO level - without
+    message coloring.
+    """
+    # Messages to log at the different standard log levels
+    log_level_msgs = {
+        level: f"Log {level_name} 6021"
+        for level, level_name in data_log_level_names_mapping.items()
+    }
+
+    # Expected stdout messages
+    stdout_msgs = ["Cotainr:-: Log INFO 6021"]
+
+    # Expected stderr messages
+    stderr_msgs = [
+        "Cotainr:-:CRITICAL: Log CRITICAL 6021",
+        "Cotainr:-:ERROR: Log ERROR 6021",
+        "Cotainr:-:WARNING: Log WARNING 6021",
     ]
 
     return log_level_msgs, stdout_msgs, stderr_msgs

--- a/cotainr/tests/cli/patches.py
+++ b/cotainr/tests/cli/patches.py
@@ -27,3 +27,36 @@ def patch_disable_main(monkeypatch):
         return msg
 
     monkeypatch.setattr(cotainr.cli, "main", mock_main)
+
+
+@pytest.fixture
+def patch_disable_cotainercli_init(monkeypatch):
+    """
+    Make the construction of the CotainrCLI a no-op.
+    """
+
+    def mock_init(self, *, args=None):
+        pass
+
+    monkeypatch.setattr(cotainr.cli.CotainrCLI, "__init__", mock_init)
+
+
+@pytest.fixture
+def patch_disables_cotainrcli_setup_cotainr_cli_logging(monkeypatch):
+    """
+    Disable the setup of the logging machinery for the cotainr CLI.
+
+    Replaces the `CotainrCLI._setup_cotainr_cli_logging` method with a method
+    that just prints and returns the `tracing.LogSettings` object provided to
+    it as an argument.
+    """
+
+    def mock_setup_cotainr_cli_logging(self, *, log_settings):
+        print(log_settings)
+        return log_settings
+
+    monkeypatch.setattr(
+        cotainr.cli.CotainrCLI,
+        "_setup_cotainr_cli_logging",
+        mock_setup_cotainr_cli_logging,
+    )

--- a/cotainr/tests/cli/stubs.py
+++ b/cotainr/tests/cli/stubs.py
@@ -7,7 +7,10 @@ Licensed under the European Union Public License (EUPL) 1.2
 
 """
 
+from pathlib import Path
+
 from cotainr.cli import CotainrSubcommand
+from cotainr.tracing import LogSettings
 
 
 class StubDummyCLI:
@@ -22,6 +25,22 @@ class StubDummyCLI:
 
 class StubInvalidSubcommand:
     pass
+
+
+class StubLogSettingsSubcommand(CotainrSubcommand):
+    def __init__(self, *, verbosity, log_file_path, no_color):
+        self.log_settings = LogSettings(
+            verbosity=verbosity, log_file_path=log_file_path, no_color=no_color
+        )
+
+    @classmethod
+    def add_arguments(cls, *, parser):
+        parser.add_argument("--verbosity", type=int)
+        parser.add_argument("--log-file-path", type=Path, default=None)
+        parser.add_argument("--no-color", action="store_true")
+
+    def execute(self):
+        pass
 
 
 class StubValidSubcommand(CotainrSubcommand):

--- a/cotainr/tests/cli/test_build.py
+++ b/cotainr/tests/cli/test_build.py
@@ -307,7 +307,7 @@ class TestExecute:
 
         # Check log calls
         assert re.search(
-            r"^WARNING  cotainr\.pack\:pack\.py\:(\d+) "
+            r"^WARNING  CondaInstall\.err\:pack\.py\:(\d+) "
             r"You have accepted the Miniforge installer license via the command line option "
             r"'--accept-licenses'\.$",
             caplog.text,

--- a/cotainr/tests/cli/test_build.py
+++ b/cotainr/tests/cli/test_build.py
@@ -24,6 +24,7 @@ from ..pack.patches import (
     patch_disable_conda_install_display_miniforge_license_for_acceptance,
     patch_disable_conda_install_download_miniforge_installer,
 )
+from ..tracing.patches import patch_disable_console_spinner
 from ..util.patches import patch_system_with_actual_file, patch_empty_system
 
 
@@ -209,6 +210,7 @@ class TestExecute:
         # add_metadata fails as there is no sandbox_dir and labels.json since
         # we request patch_disable_singularity_sandbox_subprocess_runner.
         patch_disable_add_metadata,
+        patch_disable_console_spinner,
         capsys,
     ):
         image_path = "some_image_path_6021"
@@ -235,6 +237,7 @@ class TestExecute:
         patch_disable_conda_install_download_miniforge_installer,
         patch_save_singularity_sandbox_context,
         patch_disable_add_metadata,
+        patch_disable_console_spinner,
         capsys,
     ):
         image_path = "some_image_path_6021"
@@ -332,6 +335,7 @@ class TestHelpMessage:
             # Capsys apparently assumes an 80 char terminal (?) - thus extra '\n'
             "usage: cotainr build [-h] (--base-image BASE_IMAGE | --system SYSTEM)\n"
             "                     [--conda-env CONDA_ENV] [--accept-licenses]\n"
+            "                     [--verbose | --quiet] [--log-to-file] [--no-color]\n"
             "                     image_path\n\n"
             "Build a container.\n\n"
             "positional arguments:\n"
@@ -353,4 +357,12 @@ class TestHelpMessage:
             "                        terms, as specified during the build process\n"
             "  --accept-licenses     accept all license terms (if any) needed for\n"
             "                        completing the container build process\n"
+            "  --verbose, -v         increase the verbosity of the output from cotainr. Can\n"
+            "                        be used multiple times: Once for subprocess output,\n"
+            "                        twice for subprocess INFO, three times for DEBUG, and\n"
+            "                        four times for TRACE\n"
+            "  --quiet, -q           do not show any non-CRITICAL output from cotainr\n"
+            "  --log-to-file         create files containing all logging information shown\n"
+            "                        on stdout/stderr\n"
+            "  --no-color            do not use colored console output\n"
         )

--- a/cotainr/tests/cli/test_cotainr_cli.py
+++ b/cotainr/tests/cli/test_cotainr_cli.py
@@ -176,9 +176,9 @@ class Test_SetupCotainrCLILogging:
             assert isinstance(handler, logging.StreamHandler)
 
         # Check correct logging, incl. message format, coloring, log level, and output stream
-        outerr = capsys.readouterr()  # readouterr clears its content when returning
-        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
-        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
+        stdout, stderr = capsys.readouterr()  # readouterr clears its content when returning
+        assert stdout.rstrip("\n").split("\n") == stdout_msgs
+        assert stderr.rstrip("\n").split("\n") == stderr_msgs
 
     @pytest.mark.parametrize("verbosity", [2, 3, 5, 1000])
     def test_cotainr_debug_logging(
@@ -217,9 +217,9 @@ class Test_SetupCotainrCLILogging:
             assert isinstance(handler, logging.StreamHandler)
 
         # Check correct logging, incl. message format, coloring, log level, and output stream
-        outerr = capsys.readouterr()  # readouterr clears its content when returning
-        actual_stdout_msgs = outerr.out.rstrip("\n").split("\n")
-        actual_stderr_msgs = outerr.err.rstrip("\n").split("\n")
+        stdout, stderr = capsys.readouterr()  # readouterr clears its content when returning
+        actual_stdout_msgs = stdout.rstrip("\n").split("\n")
+        actual_stderr_msgs = stderr.rstrip("\n").split("\n")
         assert len(actual_stdout_msgs) == len(expected_stdout_msgs)
         assert len(actual_stderr_msgs) == len(expected_stderr_msgs)
         debug_msg_start_re = re.compile(
@@ -267,9 +267,9 @@ class Test_SetupCotainrCLILogging:
             assert isinstance(handler, logging.StreamHandler)
 
         # Check correct logging, incl. message format, coloring, log level, and output stream
-        outerr = capsys.readouterr()  # readouterr clears its content when returning
-        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
-        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
+        stdout, stderr = capsys.readouterr()  # readouterr clears its content when returning
+        assert stdout.rstrip("\n").split("\n") == stdout_msgs
+        assert stderr.rstrip("\n").split("\n") == stderr_msgs
 
     @pytest.mark.parametrize("no_color", [True, False])
     def test_log_to_file(
@@ -353,6 +353,6 @@ class Test_SetupCotainrCLILogging:
             assert isinstance(handler, logging.StreamHandler)
 
         # Check correct logging, incl. message format, coloring, log level, and output stream
-        outerr = capsys.readouterr()  # readouterr clears its content when returning
-        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
-        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
+        stdout, stderr = capsys.readouterr()  # readouterr clears its content when returning
+        assert stdout.rstrip("\n").split("\n") == stdout_msgs
+        assert stderr.rstrip("\n").split("\n") == stderr_msgs

--- a/cotainr/tests/cli/test_cotainr_cli.py
+++ b/cotainr/tests/cli/test_cotainr_cli.py
@@ -138,7 +138,7 @@ class TestHelpMessage:
         )
 
 
-class TestSetupCotainrCLILogging:
+class Test_SetupCotainrCLILogging:
     @pytest.mark.parametrize("verbosity", [-1, -2, -3, -5, -1000])
     def test_cotainr_critical_logging(
         self,

--- a/cotainr/tests/cli/test_cotainr_cli.py
+++ b/cotainr/tests/cli/test_cotainr_cli.py
@@ -271,43 +271,6 @@ class TestSetupCotainrCLILogging:
         assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
         assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
 
-    def test_no_color_on_console(
-        self,
-        capsys,
-        data_cotainr_info_no_color_log_messages,
-        patch_disable_cotainercli_init,
-    ):
-        (
-            log_level_msgs,
-            stdout_msgs,
-            stderr_msgs,
-        ) = data_cotainr_info_no_color_log_messages
-
-        # Setup the CotainerCLI logger
-        CotainrCLI()._setup_cotainr_cli_logging(
-            log_settings=LogSettings(verbosity=0, log_file_path=None, no_color=True)
-        )
-        assert "cotainr" in logging.Logger.manager.loggerDict
-
-        # Log test messages to cotainr root logger
-        cotainr_root_logger = logging.getLogger("cotainr")
-        for level, msg in log_level_msgs.items():
-            cotainr_root_logger.log(level=level, msg=msg)
-
-        # Check correct log level
-        assert cotainr_root_logger.getEffectiveLevel() == logging.INFO
-
-        # Check correct handles
-        # Pytest manipulates the handler streams to capture the logging output
-        assert len(cotainr_root_logger.handlers) == 2
-        for handler in cotainr_root_logger.handlers:
-            assert isinstance(handler, logging.StreamHandler)
-
-        # Check correct logging, incl. message format, coloring, log level, and output stream
-        outerr = capsys.readouterr()  # readouterr clears its content when returning
-        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
-        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
-
     @pytest.mark.parametrize("no_color", [True, False])
     def test_log_to_file(
         self,
@@ -356,3 +319,40 @@ class TestSetupCotainrCLILogging:
             log_file_path.with_suffix(".err").read_text().rstrip("\n").split("\n")
             == stderr_msgs
         )
+
+    def test_no_color_on_console(
+        self,
+        capsys,
+        data_cotainr_info_no_color_log_messages,
+        patch_disable_cotainercli_init,
+    ):
+        (
+            log_level_msgs,
+            stdout_msgs,
+            stderr_msgs,
+        ) = data_cotainr_info_no_color_log_messages
+
+        # Setup the CotainerCLI logger
+        CotainrCLI()._setup_cotainr_cli_logging(
+            log_settings=LogSettings(verbosity=0, log_file_path=None, no_color=True)
+        )
+        assert "cotainr" in logging.Logger.manager.loggerDict
+
+        # Log test messages to cotainr root logger
+        cotainr_root_logger = logging.getLogger("cotainr")
+        for level, msg in log_level_msgs.items():
+            cotainr_root_logger.log(level=level, msg=msg)
+
+        # Check correct log level
+        assert cotainr_root_logger.getEffectiveLevel() == logging.INFO
+
+        # Check correct handles
+        # Pytest manipulates the handler streams to capture the logging output
+        assert len(cotainr_root_logger.handlers) == 2
+        for handler in cotainr_root_logger.handlers:
+            assert isinstance(handler, logging.StreamHandler)
+
+        # Check correct logging, incl. message format, coloring, log level, and output stream
+        outerr = capsys.readouterr()  # readouterr clears its content when returning
+        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
+        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs

--- a/cotainr/tests/cli/test_info.py
+++ b/cotainr/tests/cli/test_info.py
@@ -98,7 +98,7 @@ class Test_check_python_dependency:
         assert re.match(
             (
                 r"^Running python \d+\.\d+\.\d+ (>=)|(<) \d+\.\d+\.\d+, "
-                r"(\\033\[92mOK\\033\[0m)|(\\033\[91mERROR\\033\[0m)$"
+                r"(\\x1b\[38;5;1mOK\\x1b\[0m)|(\\x1b\[38;5;1mERROR\\x1b\[0m)$"
             ),
             Info()._check_python_dependency(),
         )
@@ -113,7 +113,7 @@ class Test_check_singularity_dependency:
         )
         assert (
             Info()._check_singularity_dependency()
-            == "Found apptainer 1.0.0 >= 1.0.0, \x1b[92mOK\x1b[0m"
+            == "Found apptainer 1.0.0 >= 1.0.0, \x1b[38;5;2mOK\x1b[0m"
         )
 
     def test_found_singularity(self, monkeypatch):
@@ -124,7 +124,7 @@ class Test_check_singularity_dependency:
         )
         assert (
             Info()._check_singularity_dependency()
-            == "Found singularity 3.7.4-1 >= 3.7.4, \x1b[92mOK\x1b[0m"
+            == "Found singularity 3.7.4-1 >= 3.7.4, \x1b[38;5;2mOK\x1b[0m"
         )
 
     def test_found_unknown(self, monkeypatch):
@@ -149,7 +149,7 @@ class Test_check_singularity_dependency:
         )
         assert (
             Info()._check_singularity_dependency()
-            == "apptainer/singularity not found, \033[91mERROR\033[0m"
+            == "apptainer/singularity not found, \x1b[38;5;1mERROR\x1b[0m"
         )
 
 
@@ -157,10 +157,10 @@ class Test_check_version:
     @pytest.mark.parametrize(
         "version,min_version,cmp_result",
         [
-            ((3, 8, 0), (3, 8, 0), ">= 3.8.0, \x1b[92mOK\x1b[0m"),
-            ((0, 1, 12), (0, 0, 1), ">= 0.0.1, \x1b[92mOK\x1b[0m"),
-            ((3, 7, 14), (3, 8, 0), "< 3.8.0, \033[91mERROR\033[0m"),
-            ((1, 0, 0), (3, 8, 0), "< 3.8.0, \033[91mERROR\033[0m"),
+            ((3, 8, 0), (3, 8, 0), ">= 3.8.0, \x1b[38;5;2mOK\x1b[0m"),
+            ((0, 1, 12), (0, 0, 1), ">= 0.0.1, \x1b[38;5;2mOK\x1b[0m"),
+            ((3, 7, 14), (3, 8, 0), "< 3.8.0, \x1b[38;5;1mERROR\x1b[0m"),
+            ((1, 0, 0), (3, 8, 0), "< 3.8.0, \x1b[38;5;1mERROR\x1b[0m"),
         ],
     )
     def test_version_comparison(self, version, min_version, cmp_result):

--- a/cotainr/tests/conftest.py
+++ b/cotainr/tests/conftest.py
@@ -36,7 +36,7 @@ def argparse_options_line():
         return "optional arguments:\n"
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def context_reload_logging():
     """
     Reset the internal state of the logging module on test teardown.
@@ -44,7 +44,7 @@ def context_reload_logging():
     Needed in tests of logging functionality where the tests end up affecting
     the internal state of the logging module.
 
-    See https://stackoverflow.com/q/7460363 for more details.
+    See https://stackoverflow.com/q/7460363 for more context.
     """
     yield
     importlib.reload(logging)

--- a/cotainr/tests/conftest.py
+++ b/cotainr/tests/conftest.py
@@ -52,6 +52,28 @@ def context_set_umask():
 
 
 @pytest.fixture
+def factory_mock_input():
+    """
+    Create mock of the builtins `input` function that returns a fixed "input".
+
+    Returns a factory for creating mocked versions of the builtin `input`
+    function to be used with the `monkeypatch` fixture to replace
+    `builtins.input` with a function that prints the prompt (its argument, if
+    provided) and returns a "fixed user input", provided as argument to the
+    factory.
+    """
+
+    def create_mock_input(fixed_user_input=None):
+        def mock_input(prompt):
+            print(prompt, end="")
+            return fixed_user_input
+
+        return mock_input
+
+    return create_mock_input
+
+
+@pytest.fixture
 def patch_urllib_urlopen_as_bytes_stream(monkeypatch):
     """
     Disable urllib.request.urlopen(...).

--- a/cotainr/tests/conftest.py
+++ b/cotainr/tests/conftest.py
@@ -8,6 +8,8 @@ Licensed under the European Union Public License (EUPL) 1.2
 """
 
 import contextlib
+import logging
+import importlib
 import io
 import os
 from pathlib import Path
@@ -35,6 +37,20 @@ def argparse_options_line():
 
 
 @pytest.fixture
+def context_reload_logging():
+    """
+    Reset the internal state of the logging module on test teardown.
+
+    Needed in tests of logging functionality where the tests end up affecting
+    the internal state of the logging module.
+
+    See https://stackoverflow.com/q/7460363 for more details.
+    """
+    yield
+    importlib.reload(logging)
+
+
+@pytest.fixture
 def context_set_umask():
     """Return a context manager providing a context with the specified umask."""
 
@@ -49,6 +65,28 @@ def context_set_umask():
                 os.umask(current_umask)
 
     return set_umask
+
+
+@pytest.fixture
+def data_log_level_names_mapping():
+    """
+    A mapping from log levels to their names.
+
+    From Python 3.11 this mapping is also available as
+    logging.getLevelNamesMapping().
+    """
+    level_names_mapping = {
+        level: logging.getLevelName(level)
+        for level in [
+            logging.CRITICAL,
+            logging.ERROR,
+            logging.WARNING,
+            logging.INFO,
+            logging.DEBUG,
+        ]
+    }
+
+    return level_names_mapping
 
 
 @pytest.fixture

--- a/cotainr/tests/container/test_singularity_sandbox.py
+++ b/cotainr/tests/container/test_singularity_sandbox.py
@@ -42,6 +42,12 @@ class TestConstructor:
 
 
 class TestContext:
+    def test_add_verbosity_arg(self, capsys, patch_disable_stream_subprocess):
+        with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
+            pass
+        stdout_lines = capsys.readouterr().out.rstrip("\n").split("\n")
+        assert "args=['singularity', '-q', " in stdout_lines[0]
+
     @pytest.mark.singularity_integration
     def test_singularity_sandbox_creation(self, data_cached_alpine_sif):
         with SingularitySandbox(base_image=data_cached_alpine_sif) as sandbox:
@@ -95,6 +101,12 @@ class TestAddToEnv:
 
 @pytest.mark.singularity_integration
 class TestBuildImage:
+    def test_add_verbosity_arg(self, capsys, patch_disable_stream_subprocess):
+        with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
+            sandbox.build_image(path="some_path_6021")
+        stdout_lines = capsys.readouterr().out.rstrip("\n").split("\n")
+        assert "args=['singularity', '-q', " in stdout_lines[-1]
+
     def test_overwrite_existing_image(self, data_cached_alpine_sif, tmp_path):
         existing_singularity_image_path = tmp_path / "existing_image_6021"
         existing_singularity_image_path.write_bytes(data_cached_alpine_sif.read_bytes())
@@ -127,6 +139,12 @@ class TestBuildImage:
 
 @pytest.mark.singularity_integration
 class TestRunCommandInContainer:
+    def test_add_verbosity_arg(self, capsys, patch_disable_stream_subprocess):
+        with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
+            sandbox.run_command_in_container(cmd="ls")
+        stdout_lines = capsys.readouterr().out.rstrip("\n").split("\n")
+        assert "args=['singularity', '-q', " in stdout_lines[-1]
+
     def test_correct_umask(self, data_cached_alpine_sif, context_set_umask):
         test_file = "test_file_6021"
         with context_set_umask(0o007):  # default umask on LUMI

--- a/cotainr/tests/container/test_singularity_sandbox.py
+++ b/cotainr/tests/container/test_singularity_sandbox.py
@@ -170,7 +170,9 @@ class Test_AssertWithinSandboxContext:
 
 class Test_SubprocessRunner:
     def test_logger_prefix_for_custom_log_dispatcher(
-        self, capsys, patch_disable_stream_subprocess
+        self,
+        capsys,
+        patch_disable_stream_subprocess,
     ):
         log_dispatcher = LogDispatcher(
             name="test_dispatcher_6021",

--- a/cotainr/tests/pack/stubs.py
+++ b/cotainr/tests/pack/stubs.py
@@ -37,5 +37,5 @@ class StubShowLicensePopen(StubLicensePopen):
         "STUB:\n"
         "Please, press ENTER to continue\n"
         ">>> \n"
-        "This is the license terms..."
+        "This is the license terms...\n"
     )

--- a/cotainr/tests/pack/test_conda_install.py
+++ b/cotainr/tests/pack/test_conda_install.py
@@ -435,6 +435,7 @@ class Test_DownloadMiniforgeInstaller:
                 b"'https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh'"
             )
 
+    @pytest.mark.conda_integration  # technically not a test that depends on Conda - but a very slow one...
     def test_installer_download_fail(
         self,
         patch_urllib_urlopen_force_fail,
@@ -481,8 +482,8 @@ class Test_LoggingFilters:
         ]
         assert filter_names == [
             "StripANSIEscapeCodes",
-            "NoEmptyLinesFilter",
             "OnlyFinalProgressbarFilter",
+            "NoEmptyLinesFilter",
         ]
 
     def test_strip_ANSI_codes_filter(
@@ -522,7 +523,7 @@ class Test_LoggingFilters:
     ):
         with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
             conda_install = CondaInstall(sandbox=sandbox, license_accepted=True)
-            filter_ = conda_install._logging_filters[1]
+            filter_ = conda_install._logging_filters[2]
             assert filter_.__class__.__name__ == "NoEmptyLinesFilter"
 
         rec = logging.LogRecord(
@@ -571,7 +572,7 @@ class Test_LoggingFilters:
     ):
         with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
             conda_install = CondaInstall(sandbox=sandbox, license_accepted=True)
-            filter_ = conda_install._logging_filters[2]
+            filter_ = conda_install._logging_filters[1]
             assert filter_.__class__.__name__ == "OnlyFinalProgressbarFilter"
 
         rec = logging.LogRecord(

--- a/cotainr/tests/pack/test_conda_install.py
+++ b/cotainr/tests/pack/test_conda_install.py
@@ -204,8 +204,9 @@ class Test_CheckCondaBootstrapIntegrity:
 
 
 class Test_DisplayMiniforgeLicenseForAcceptance:
-    def test_acccepting_license(
+    def test_accepting_license(
         self,
+        factory_mock_input,
         patch_disable_conda_install_bootstrap_conda,
         patch_disable_conda_install_download_miniforge_installer,
         patch_disable_singularity_sandbox_subprocess_runner,
@@ -213,7 +214,7 @@ class Test_DisplayMiniforgeLicenseForAcceptance:
         monkeypatch,
     ):
         monkeypatch.setattr(subprocess, "Popen", StubShowLicensePopen)
-        monkeypatch.setattr("builtins.input", lambda: "yes")
+        monkeypatch.setattr("builtins.input", factory_mock_input("yes"))
         with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
             conda_install = CondaInstall(sandbox=sandbox)
 
@@ -225,6 +226,7 @@ class Test_DisplayMiniforgeLicenseForAcceptance:
     def test_not_accepting_license(
         self,
         answer,
+        factory_mock_input,
         patch_disable_conda_install_bootstrap_conda,
         patch_disable_conda_install_download_miniforge_installer,
         patch_disable_singularity_sandbox_subprocess_runner,
@@ -232,7 +234,7 @@ class Test_DisplayMiniforgeLicenseForAcceptance:
         monkeypatch,
     ):
         monkeypatch.setattr(subprocess, "Popen", StubShowLicensePopen)
-        monkeypatch.setattr("builtins.input", lambda: answer)
+        monkeypatch.setattr("builtins.input", factory_mock_input(answer))
         with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
             with pytest.raises(SystemExit):
                 CondaInstall(sandbox=sandbox)
@@ -259,6 +261,7 @@ class Test_DisplayMiniforgeLicenseForAcceptance:
 
     def test_license_interaction_handling(
         self,
+        factory_mock_input,
         patch_disable_conda_install_bootstrap_conda,
         patch_disable_conda_install_download_miniforge_installer,
         patch_disable_singularity_sandbox_subprocess_runner,
@@ -266,7 +269,7 @@ class Test_DisplayMiniforgeLicenseForAcceptance:
         monkeypatch,
     ):
         monkeypatch.setattr(subprocess, "Popen", StubShowLicensePopen)
-        monkeypatch.setattr("builtins.input", lambda: "yes")
+        monkeypatch.setattr("builtins.input", factory_mock_input("yes"))
         with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
             CondaInstall(sandbox=sandbox)
 
@@ -286,12 +289,13 @@ class Test_DisplayMiniforgeLicenseForAcceptance:
     @pytest.mark.conda_integration
     def test_miniforge_still_showing_license(
         self,
+        factory_mock_input,
         patch_disable_conda_install_bootstrap_conda,
         patch_disable_singularity_sandbox_subprocess_runner,
         capsys,
         monkeypatch,
     ):
-        monkeypatch.setattr("builtins.input", lambda: "yes")
+        monkeypatch.setattr("builtins.input", factory_mock_input("yes"))
         with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
             conda_install = CondaInstall(sandbox=sandbox)
 

--- a/cotainr/tests/tracing/data.py
+++ b/cotainr/tests/tracing/data.py
@@ -1,0 +1,173 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+
+import pytest
+
+
+@pytest.fixture
+def data_log_dispatcher_critical_color_log_messages(data_log_level_names_mapping):
+    """
+    Log messages for standard log levels and their expected output to
+    stdout/stderr for the LogDispatcher logging machinery at CRITICAL level.
+    """
+    # Choose a logger name
+    logger_name = "LD_6021"
+
+    # Messages to log at the different standard log levels
+    log_level_msgs = {
+        level: f"Log {level_name} 6021"
+        for level, level_name in data_log_level_names_mapping.items()
+    }
+
+    # Expected stdout messages
+    stdout_msgs = ["LD_6021.out:-: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m"]
+
+    # Expected stderr messages
+    stderr_msgs = ["LD_6021.err:-: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m"]
+
+    return logger_name, log_level_msgs, stdout_msgs, stderr_msgs
+
+
+@pytest.fixture
+def data_log_dispatcher_debug_color_log_messages(data_log_level_names_mapping):
+    """
+    Log messages for standard log levels and their expected output to
+    stdout/stderr for the LogDispatcher logging machinery at DEBUG level.
+    """
+    # Choose a logger name
+    logger_name = "LD_6021"
+
+    # Messages to log at the different standard log levels
+    log_level_msgs = {
+        level: f"Log {level_name} 6021"
+        for level, level_name in data_log_level_names_mapping.items()
+    }
+
+    # Expected ending of stdout messages
+    # (debug messages are prepended with a time stamp)
+    stdout_msgs = [
+        "LD_6021.out:-:CRITICAL: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
+        "LD_6021.out:-:ERROR: \x1b[38;5;1mLog ERROR 6021\x1b[0m",
+        "LD_6021.out:-:WARNING: \x1b[38;5;3mLog WARNING 6021\x1b[0m",
+        "LD_6021.out:-:INFO: Log INFO 6021",
+        "LD_6021.out:-:DEBUG: \x1b[38;5;8mLog DEBUG 6021\x1b[0m",
+    ]
+
+    # Expected ending of stderr messages
+    # (debug messages are prepended with a time stamp)
+    stderr_msgs = [
+        "LD_6021.err:-:CRITICAL: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
+        "LD_6021.err:-:ERROR: \x1b[38;5;1mLog ERROR 6021\x1b[0m",
+        "LD_6021.err:-:WARNING: \x1b[38;5;3mLog WARNING 6021\x1b[0m",
+        "LD_6021.err:-:INFO: Log INFO 6021",
+        "LD_6021.err:-:DEBUG: \x1b[38;5;8mLog DEBUG 6021\x1b[0m",
+    ]
+
+    return logger_name, log_level_msgs, stdout_msgs, stderr_msgs
+
+
+@pytest.fixture
+def data_log_dispatcher_info_color_log_messages(data_log_level_names_mapping):
+    """
+    Log messages for standard log levels and their expected output to
+    stdout/stderr for the LogDispatcher logging machinery at INFO level.
+    """
+    # Choose a logger name
+    logger_name = "LD_6021"
+
+    # Messages to log at the different standard log levels
+    log_level_msgs = {
+        level: f"Log {level_name} 6021"
+        for level, level_name in data_log_level_names_mapping.items()
+    }
+
+    # Expected stdout messages
+    stdout_msgs = [
+        "LD_6021.out:-: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
+        "LD_6021.out:-: \x1b[38;5;1mLog ERROR 6021\x1b[0m",
+        "LD_6021.out:-: \x1b[38;5;3mLog WARNING 6021\x1b[0m",
+        "LD_6021.out:-: Log INFO 6021",
+    ]
+
+    # Expected stderr messages
+    stderr_msgs = [
+        "LD_6021.err:-: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
+        "LD_6021.err:-: \x1b[38;5;1mLog ERROR 6021\x1b[0m",
+        "LD_6021.err:-: \x1b[38;5;3mLog WARNING 6021\x1b[0m",
+        "LD_6021.err:-: Log INFO 6021",
+    ]
+
+    return logger_name, log_level_msgs, stdout_msgs, stderr_msgs
+
+
+@pytest.fixture
+def data_log_dispatcher_info_no_color_log_messages(data_log_level_names_mapping):
+    """
+    Log messages for standard log levels and their expected output to
+    stdout/stderr for the LogDispatcher logging machinery at INFO level -
+    without message coloring.
+    """
+    # Choose a logger name
+    logger_name = "LD_6021"
+
+    # Messages to log at the different standard log levels
+    log_level_msgs = {
+        level: f"Log {level_name} 6021"
+        for level, level_name in data_log_level_names_mapping.items()
+    }
+
+    # Expected stdout messages
+    stdout_msgs = [
+        "LD_6021.out:-: Log CRITICAL 6021",
+        "LD_6021.out:-: Log ERROR 6021",
+        "LD_6021.out:-: Log WARNING 6021",
+        "LD_6021.out:-: Log INFO 6021",
+    ]
+
+    # Expected stderr messages
+    stderr_msgs = [
+        "LD_6021.err:-: Log CRITICAL 6021",
+        "LD_6021.err:-: Log ERROR 6021",
+        "LD_6021.err:-: Log WARNING 6021",
+        "LD_6021.err:-: Log INFO 6021",
+    ]
+
+    return logger_name, log_level_msgs, stdout_msgs, stderr_msgs
+
+
+@pytest.fixture
+def data_log_dispatcher_warning_color_log_messages(data_log_level_names_mapping):
+    """
+    Log messages for standard log levels and their expected output to
+    stdout/stderr for the LogDispatcher logging machinery at WARNING level.
+    """
+    # Choose a logger name
+    logger_name = "LD_6021"
+
+    # Messages to log at the different standard log levels
+    log_level_msgs = {
+        level: f"Log {level_name} 6021"
+        for level, level_name in data_log_level_names_mapping.items()
+    }
+
+    # Expected stdout messages
+    stdout_msgs = [
+        "LD_6021.out:-: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
+        "LD_6021.out:-: \x1b[38;5;1mLog ERROR 6021\x1b[0m",
+        "LD_6021.out:-: \x1b[38;5;3mLog WARNING 6021\x1b[0m",
+    ]
+
+    # Expected stderr messages
+    stderr_msgs = [
+        "LD_6021.err:-: \x1b[38;5;160mLog CRITICAL 6021\x1b[0m",
+        "LD_6021.err:-: \x1b[38;5;1mLog ERROR 6021\x1b[0m",
+        "LD_6021.err:-: \x1b[38;5;3mLog WARNING 6021\x1b[0m",
+    ]
+
+    return logger_name, log_level_msgs, stdout_msgs, stderr_msgs

--- a/cotainr/tests/tracing/patches.py
+++ b/cotainr/tests/tracing/patches.py
@@ -11,6 +11,7 @@ import contextlib
 import pytest
 
 import cotainr.tracing
+from .stubs import FixedNumberOfSpinsEvent
 
 
 @pytest.fixture
@@ -26,3 +27,23 @@ def patch_disable_console_spinner(monkeypatch):
         yield
 
     monkeypatch.setattr(cotainr.tracing, "ConsoleSpinner", mock_console_spinner)
+
+
+@pytest.fixture
+def patch_fix_number_of_message_spins(spins, monkeypatch):
+    """
+    Force `cotainr.tracing.MessageSpinner` to update the spinning message
+    exactly `spins` times before stopping.
+
+    The `spin` parameter must be passed to the fixture using a pytest
+    parameterization.
+    """
+
+    class FixedNumberOfSpinsMessageSpinner(cotainr.tracing.MessageSpinner):
+        def __init__(self, *, msg, stream):
+            super().__init__(msg=msg, stream=stream)
+            self._stop_signal = FixedNumberOfSpinsEvent(spins=spins)
+
+    monkeypatch.setattr(
+        cotainr.tracing, "MessageSpinner", FixedNumberOfSpinsMessageSpinner
+    )

--- a/cotainr/tests/tracing/patches.py
+++ b/cotainr/tests/tracing/patches.py
@@ -1,0 +1,28 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+import contextlib
+
+import pytest
+
+import cotainr.tracing
+
+
+@pytest.fixture
+def patch_disable_console_spinner(monkeypatch):
+    """
+    Disable the ConsoleSpinner() context.
+
+    Replaces the console spinner context with a no-op context.
+    """
+
+    @contextlib.contextmanager
+    def mock_console_spinner():
+        yield
+
+    monkeypatch.setattr(cotainr.tracing, "ConsoleSpinner", mock_console_spinner)

--- a/cotainr/tests/tracing/stubs.py
+++ b/cotainr/tests/tracing/stubs.py
@@ -1,0 +1,33 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+
+
+class AlwaysCompareFalse:
+    """A stub that returns False for all Python "rich comparisons"."""
+
+    def __lt__(self, other):
+        return False
+
+    def __le__(self, other):
+        return False
+
+    def __eq__(self, other):
+        return False
+
+    def __ne__(self, other):
+        return False
+
+    def __gt__(self, other):
+        return False
+
+    def __ge__(self, other):
+        return False
+
+    def __repr__(self):
+        return "AlwaysCompareFalseStub"

--- a/cotainr/tests/tracing/stubs.py
+++ b/cotainr/tests/tracing/stubs.py
@@ -8,6 +8,9 @@ Licensed under the European Union Public License (EUPL) 1.2
 """
 
 
+import contextlib
+
+
 class AlwaysCompareFalse:
     """A stub that returns False for all Python "rich comparisons"."""
 
@@ -52,3 +55,9 @@ class FixedNumberOfSpinsEvent:
 
     def set(self):
         self.remaining_spins = 0
+
+
+@contextlib.contextmanager
+def RaiseOnEnterContext():
+    raise NotImplementedError("Entered context")
+    yield

--- a/cotainr/tests/tracing/stubs.py
+++ b/cotainr/tests/tracing/stubs.py
@@ -31,3 +31,24 @@ class AlwaysCompareFalse:
 
     def __repr__(self):
         return "AlwaysCompareFalseStub"
+
+
+class FixedNumberOfSpinsEvent:
+    """
+    An event that fixes the number of times the message is spun in a MessageSpinner.
+    """
+
+    def __init__(self, *, spins):
+        assert isinstance(spins, int)
+        assert spins >= 0
+        self.remaining_spins = spins
+
+    def is_set(self):
+        if self.remaining_spins == 0:
+            return True
+        else:
+            self.remaining_spins -= 1
+            return False
+
+    def set(self):
+        self.remaining_spins = 0

--- a/cotainr/tests/tracing/stubs.py
+++ b/cotainr/tests/tracing/stubs.py
@@ -54,7 +54,7 @@ class FixedNumberOfSpinsEvent:
             return False
 
     def set(self):
-        self.remaining_spins = 0
+        pass
 
 
 @contextlib.contextmanager

--- a/cotainr/tests/tracing/test_coloured_output_formatter.py
+++ b/cotainr/tests/tracing/test_coloured_output_formatter.py
@@ -1,0 +1,71 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+import logging
+
+import pytest
+
+from cotainr.tracing import ColoredOutputFormatter
+
+
+class TestClassAttributes:
+    def test_log_level_fg_colors(self):
+        assert hasattr(ColoredOutputFormatter, "log_level_fg_colors")
+        assert isinstance(ColoredOutputFormatter.log_level_fg_colors, dict)
+        for log_level in [
+            logging.DEBUG,
+            logging.INFO,
+            logging.WARNING,
+            logging.ERROR,
+            logging.CRITICAL,
+        ]:
+            assert log_level in ColoredOutputFormatter.log_level_fg_colors
+
+    def test_reset_color(self):
+        assert hasattr(ColoredOutputFormatter, "reset_color")
+        assert ColoredOutputFormatter.reset_color == "\x1b[0m"
+
+
+class TestFormat:
+    @pytest.mark.parametrize(
+        ["level", "msg", "color_msg"],
+        [
+            (logging.DEBUG, "test_debug", "\x1b[38;5;8mtest_debug\x1b[0m"),
+            (logging.INFO, "test_info", "test_info"),
+            (logging.WARNING, "test_warning", "\x1b[38;5;3mtest_warning\x1b[0m"),
+            (logging.ERROR, "test_error", "\x1b[38;5;1mtest_error\x1b[0m"),
+            (logging.CRITICAL, "test_critical", "\x1b[38;5;160mtest_critical\x1b[0m"),
+        ],
+    )
+    def test_correct_formatting(self, level, msg, color_msg):
+        formatter = ColoredOutputFormatter()
+        rec = logging.LogRecord(
+            name="test",
+            level=level,
+            pathname="test_path",
+            lineno=0,
+            msg=msg,
+            args=None,
+            exc_info=None,
+        )
+        assert formatter.format(rec) == color_msg
+
+    def test_original_record_unchanged(self):
+        formatter = ColoredOutputFormatter()
+        rec = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="test_path",
+            lineno=0,
+            msg="test_msg",
+            args=None,
+            exc_info=None,
+        )
+        msg = formatter.format(rec)
+        assert msg is not rec.msg
+        assert rec.msg == "test_msg"

--- a/cotainr/tests/tracing/test_console_spinner.py
+++ b/cotainr/tests/tracing/test_console_spinner.py
@@ -6,10 +6,12 @@ Licensed under the European Union Public License (EUPL) 1.2
 - see the LICENSE file for details.
 
 """
+import contextlib
 import sys
 
 import pytest
 
+import cotainr.tracing
 from cotainr.tracing import ConsoleSpinner, StreamWriteProxy
 from .patches import patch_fix_number_of_message_spins
 from .stubs import RaiseOnEnterContext
@@ -17,30 +19,39 @@ from .stubs import RaiseOnEnterContext
 
 class TestConstructor:
     def test_attributes(self):
-        spinner = ConsoleSpinner()
-        assert isinstance(spinner._stdout_proxy, StreamWriteProxy)
-        assert spinner._stdout_proxy._stream is sys.stdout
-        assert isinstance(spinner._stderr_proxy, StreamWriteProxy)
-        assert spinner._stderr_proxy._stream is sys.stderr
-        assert spinner._true_input_func is input
-        assert spinner._spinning_msg is None
+        console_spinner = ConsoleSpinner()
+        assert isinstance(console_spinner._stdout_proxy, StreamWriteProxy)
+        assert console_spinner._stdout_proxy._stream is sys.stdout
+        assert isinstance(console_spinner._stderr_proxy, StreamWriteProxy)
+        assert console_spinner._stderr_proxy._stream is sys.stderr
+        assert console_spinner._true_input_func is input
+        assert console_spinner._spinning_msg is None
+        assert not console_spinner._nested_context
 
 
 class TestContext:
-    def test_as_atomic_enter(self):
-        console_spinner = ConsoleSpinner()
-        console_spinner._as_atomic = RaiseOnEnterContext()
-        with pytest.raises(NotImplementedError, match=r"^Entered context$"):
-            console_spinner.__enter__()
+    def test_correctly_handling_input(self, factory_mock_input, capsys, monkeypatch):
+        monkeypatch.setattr("builtins.input", factory_mock_input("some_input_6021"))
+        with ConsoleSpinner():
+            input("please_input_some_text_6021")
 
-    def test_as_atomic_exit(self):
-        console_spinner = ConsoleSpinner()
-        console_spinner._as_atomic = RaiseOnEnterContext()
-        with pytest.raises(NotImplementedError, match=r"^Entered context$"):
-            console_spinner.__exit__(None, None, None)
+        stdout = capsys.readouterr().out
+        assert stdout == "please_input_some_text_6021"
 
-    def test_correctly_handling_input(self):
-        1 / 0
+    def test_correctly_setting_nested_context_flag(self):
+        with ConsoleSpinner() as level_1_spinner:
+            assert not level_1_spinner._nested_context
+            with ConsoleSpinner() as level_2_spinner:
+                assert not level_1_spinner._nested_context
+                assert level_2_spinner._nested_context
+
+            assert not level_1_spinner._nested_context
+
+    def test_correctly_setting_within_context_flag(self):
+        assert not cotainr.tracing._within_console_spinner_context
+        with ConsoleSpinner():
+            assert cotainr.tracing._within_console_spinner_context
+        assert not cotainr.tracing._within_console_spinner_context
 
     @pytest.mark.parametrize("spins", [1])
     def test_correctly_spinning_stdout_msg(
@@ -64,8 +75,13 @@ class TestContext:
         spin_and_final_line = "\r\x1b[2K⣾ test_6021..." + "\r\x1b[2Ktest_6021\n"
         assert stderr == spin_and_final_line
 
-    def test_exiting_context_with_spinning_msg(self):
-        1 / 0
+    def test_exiting_context_with_spinning_msg(self, capsys):
+        with ConsoleSpinner():
+            sys.stdout.write("test_6021")
+
+        stdout, stderr = capsys.readouterr()
+        assert stdout.endswith("\r\x1b[2Ktest_6021\n")
+        assert not stderr
 
     def test_exiting_context_without_spinning_msg(self, capsys):
         with ConsoleSpinner():
@@ -75,8 +91,32 @@ class TestContext:
         assert not stdout
         assert not stderr
 
+    def test_lock_enter(self):
+        console_spinner = ConsoleSpinner()
+        console_spinner._lock = RaiseOnEnterContext()
+        with pytest.raises(NotImplementedError, match=r"^Entered context$"):
+            console_spinner.__enter__()
+
+    def test_lock_exit(self):
+        console_spinner = ConsoleSpinner()
+        console_spinner._lock = RaiseOnEnterContext()
+        with pytest.raises(NotImplementedError, match=r"^Entered context$"):
+            console_spinner.__exit__(None, None, None)
+
+    def test_return_self(self):
+        with ConsoleSpinner() as console_spinner:
+            assert isinstance(console_spinner, ConsoleSpinner)
+
     @pytest.mark.parametrize("spins", [1])
-    def test_reentering_context(self, spins, capsys, patch_fix_number_of_message_spins):
+    def test_reentering_context(
+        self,
+        spins,
+        capsys,
+        monkeypatch,
+        factory_mock_input,
+        patch_fix_number_of_message_spins,
+    ):
+        monkeypatch.setattr("builtins.input", factory_mock_input())
         with ConsoleSpinner():
             sys.stdout.write("test_6021_level_1")
             with ConsoleSpinner():
@@ -84,6 +124,8 @@ class TestContext:
                 with ConsoleSpinner():
                     with ConsoleSpinner():
                         sys.stdout.write("test_6021_level_4")
+                        with ConsoleSpinner():
+                            input("level_5_test_input_6021")
 
         stdout = capsys.readouterr().out
         level_1_spin_and_final_line = (
@@ -99,10 +141,8 @@ class TestContext:
             level_1_spin_and_final_line
             + level_2_spin_and_final_line
             + level_4_spin_and_final_line
+            + "level_5_test_input_6021"
         )
-
-    def test_return_self(self):
-        1/0
 
     @pytest.mark.parametrize("spins", [1])
     def test_switching_from_stdout_to_stderr(
@@ -155,10 +195,39 @@ class TestContext:
         assert stdout == spin_and_final_line
 
 
-class Test_UpdateSpinnerMsg:
-    def test_as_atomic(self):
+class Test_Disable:
+    def test_lock(self):
         console_spinner = ConsoleSpinner()
-        console_spinner._as_atomic = RaiseOnEnterContext()
+        console_spinner._lock = RaiseOnEnterContext()
+        with pytest.raises(NotImplementedError, match=r"^Entered context$"):
+            with console_spinner._disable():
+                pass
+
+    def test_correctly_disabling_spinner(self, capsys):
+        with ConsoleSpinner() as console_spinner:
+            with console_spinner._disable():
+                sys.stdout.write("test_6021")
+
+        stdout = capsys.readouterr().out
+        assert stdout == "test_6021"
+
+    def test_raise_on_disable_outside_context(self):
+        console_spinner = ConsoleSpinner()
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"^Disabling the spinner is only allowed inside "
+                r"the ConsoleSpinner context.$"
+            ),
+        ):
+            with console_spinner._disable():
+                pass
+
+
+class Test_UpdateSpinnerMsg:
+    def test_lock(self):
+        console_spinner = ConsoleSpinner()
+        console_spinner._lock = RaiseOnEnterContext()
         with pytest.raises(NotImplementedError, match=r"^Entered context$"):
             console_spinner._update_spinner_msg("", stream=None)
 
@@ -210,15 +279,37 @@ class Test_UpdateSpinnerMsg:
 
 
 class Test_ThreadSafeInput:
-    def test_as_atomic(self):
+    def test_lock(self):
         console_spinner = ConsoleSpinner()
-        console_spinner._as_atomic = RaiseOnEnterContext()
+        console_spinner._lock = RaiseOnEnterContext()
         wrapped_input_func = console_spinner._thread_safe_input(lambda: None)
         with pytest.raises(NotImplementedError, match=r"^Entered context$"):
             wrapped_input_func()
 
+    def test_disable_console_spinner(self, monkeypatch):
+        @contextlib.contextmanager
+        def raise_on_disable():
+            raise NotImplementedError("Entered disable context!")
+
+        console_spinner = ConsoleSpinner()
+        console_spinner._disable = raise_on_disable
+        with pytest.raises(NotImplementedError, match=r"^Entered disable context!$"):
+            console_spinner._thread_safe_input(input)()
+
     def test_stop_spinning_msg(self):
-        1 / 0
+        class DummyMsg:
+            def stop(self):
+                pass
+
+        console_spinner = ConsoleSpinner()
+        console_spinner._spinning_msg = DummyMsg()
+        with console_spinner:
+            console_spinner._thread_safe_input(lambda: None)()
+            assert console_spinner._spinning_msg is None
 
     def test_wrap_input_func(self):
-        1 / 0
+        def my_input_func():
+            return "test_6021"
+
+        with ConsoleSpinner() as console_spinner:
+            assert console_spinner._thread_safe_input(my_input_func)() == "test_6021"

--- a/cotainr/tests/tracing/test_console_spinner.py
+++ b/cotainr/tests/tracing/test_console_spinner.py
@@ -11,6 +11,7 @@ import sys
 import pytest
 
 from cotainr.tracing import ConsoleSpinner, StreamWriteProxy
+from .patches import patch_fix_number_of_message_spins
 from .stubs import RaiseOnEnterContext
 
 
@@ -41,20 +42,117 @@ class TestContext:
     def test_correctly_handling_input(self):
         1 / 0
 
-    def test_correctly_spinning_stdout_msg(self):
-        1 / 0
+    @pytest.mark.parametrize("spins", [1])
+    def test_correctly_spinning_stdout_msg(
+        self, spins, capsys, patch_fix_number_of_message_spins
+    ):
+        with ConsoleSpinner():
+            sys.stdout.write("test_6021")
 
-    def test_correctly_spinning_stderr_msg(self):
-        1 / 0
+        stdout = capsys.readouterr().out
+        spin_and_final_line = "\r\x1b[2K⣾ test_6021..." + "\r\x1b[2Ktest_6021\n"
+        assert stdout == spin_and_final_line
+
+    @pytest.mark.parametrize("spins", [1])
+    def test_correctly_spinning_stderr_msg(
+        self, spins, capsys, patch_fix_number_of_message_spins
+    ):
+        with ConsoleSpinner():
+            sys.stderr.write("test_6021")
+
+        stderr = capsys.readouterr().err
+        spin_and_final_line = "\r\x1b[2K⣾ test_6021..." + "\r\x1b[2Ktest_6021\n"
+        assert stderr == spin_and_final_line
 
     def test_exiting_context_with_spinning_msg(self):
         1 / 0
 
-    def test_exiting_context_without_spinnnig_msg(self):
-        1 / 0
+    def test_exiting_context_without_spinning_msg(self, capsys):
+        with ConsoleSpinner():
+            pass
 
-    def test_reentering_context(self):
-        1 / 0
+        stdout, stderr = capsys.readouterr()
+        assert not stdout
+        assert not stderr
+
+    @pytest.mark.parametrize("spins", [1])
+    def test_reentering_context(self, spins, capsys, patch_fix_number_of_message_spins):
+        with ConsoleSpinner():
+            sys.stdout.write("test_6021_level_1")
+            with ConsoleSpinner():
+                sys.stdout.write("test_6021_level_2")
+                with ConsoleSpinner():
+                    with ConsoleSpinner():
+                        sys.stdout.write("test_6021_level_4")
+
+        stdout = capsys.readouterr().out
+        level_1_spin_and_final_line = (
+            "\r\x1b[2K⣾ test_6021_level_1..." + "\r\x1b[2Ktest_6021_level_1\n"
+        )
+        level_2_spin_and_final_line = (
+            "\r\x1b[2K⣾ test_6021_level_2..." + "\r\x1b[2Ktest_6021_level_2\n"
+        )
+        level_4_spin_and_final_line = (
+            "\r\x1b[2K⣾ test_6021_level_4..." + "\r\x1b[2Ktest_6021_level_4\n"
+        )
+        assert stdout == (
+            level_1_spin_and_final_line
+            + level_2_spin_and_final_line
+            + level_4_spin_and_final_line
+        )
+
+    def test_return_self(self):
+        1/0
+
+    @pytest.mark.parametrize("spins", [1])
+    def test_switching_from_stdout_to_stderr(
+        self, spins, capsys, patch_fix_number_of_message_spins
+    ):
+        with ConsoleSpinner():
+            sys.stdout.write("test_6021_stdout")
+            sys.stderr.write("test_6021_stderr")
+
+        stdout, stderr = capsys.readouterr()
+        stdout_spin_and_final_line = (
+            "\r\x1b[2K⣾ test_6021_stdout..." + "\r\x1b[2Ktest_6021_stdout\n"
+        )
+        stderr_spin_and_final_line = (
+            "\r\x1b[2K⣾ test_6021_stderr..." + "\r\x1b[2Ktest_6021_stderr\n"
+        )
+        assert stdout == stdout_spin_and_final_line
+        assert stderr == stderr_spin_and_final_line
+
+    @pytest.mark.parametrize("spins", [1])
+    def test_switching_from_stderr_to_stdout(
+        self, spins, capsys, patch_fix_number_of_message_spins
+    ):
+        with ConsoleSpinner():
+            sys.stderr.write("test_6021_stderr")
+            sys.stdout.write("test_6021_stdout")
+
+        stdout, stderr = capsys.readouterr()
+        stdout_spin_and_final_line = (
+            "\r\x1b[2K⣾ test_6021_stdout..." + "\r\x1b[2Ktest_6021_stdout\n"
+        )
+        stderr_spin_and_final_line = (
+            "\r\x1b[2K⣾ test_6021_stderr..." + "\r\x1b[2Ktest_6021_stderr\n"
+        )
+        assert stdout == stdout_spin_and_final_line
+        assert stderr == stderr_spin_and_final_line
+
+    @pytest.mark.parametrize("spins", [1])
+    def test_updating_via_print_function(
+        self, spins, capsys, patch_fix_number_of_message_spins
+    ):
+        # print() works by making two writes to the file/stream:
+        # 1. The actual message to write
+        # 2. The `end` keyword
+        with ConsoleSpinner():
+            print("test_6021")
+
+        stdout = capsys.readouterr().out
+        spin_and_final_line = "\r\x1b[2K⣾ test_6021..." + "\r\x1b[2Ktest_6021\n"
+        assert stdout == spin_and_final_line
 
 
 class Test_UpdateSpinnerMsg:
@@ -64,11 +162,51 @@ class Test_UpdateSpinnerMsg:
         with pytest.raises(NotImplementedError, match=r"^Entered context$"):
             console_spinner._update_spinner_msg("", stream=None)
 
-    def test_first_message_correctly_started(self):
-        1 / 0
+    @pytest.mark.parametrize("spins", [1])
+    def test_first_message_correctly_started(
+        self, spins, capsys, patch_fix_number_of_message_spins
+    ):
+        console_spinner = ConsoleSpinner()
+        console_spinner._update_spinner_msg("test_6021", stream=sys.stdout)
+        console_spinner._spinning_msg.stop()
 
-    def test_message_correctly_updated(self):
-        1 / 0
+        stdout = capsys.readouterr().out
+        spin_and_final_line = "\r\x1b[2K⣾ test_6021..." + "\r\x1b[2Ktest_6021\n"
+        assert stdout == spin_and_final_line
+
+    @pytest.mark.parametrize("spins", [1])
+    def test_message_correctly_updated(
+        self, spins, capsys, patch_fix_number_of_message_spins
+    ):
+        console_spinner = ConsoleSpinner()
+        console_spinner._update_spinner_msg("test_6021_line_1", stream=sys.stdout)
+        console_spinner._update_spinner_msg("test_6021_line_2", stream=sys.stdout)
+        console_spinner._spinning_msg.stop()
+
+        stdout = capsys.readouterr().out
+        msg_1_spin_and_final_line = (
+            "\r\x1b[2K⣾ test_6021_line_1..." + "\r\x1b[2Ktest_6021_line_1\n"
+        )
+        msg_2_spin_and_final_line = (
+            "\r\x1b[2K⣾ test_6021_line_2..." + "\r\x1b[2Ktest_6021_line_2\n"
+        )
+        assert stdout == msg_1_spin_and_final_line + msg_2_spin_and_final_line
+
+    @pytest.mark.parametrize("spins", [1])
+    def test_not_updating_on_empty_message(
+        self, spins, capsys, patch_fix_number_of_message_spins
+    ):
+        console_spinner = ConsoleSpinner()
+        console_spinner._update_spinner_msg("test_6021", stream=sys.stdout)
+        console_spinner._update_spinner_msg("", stream=sys.stdout)
+        console_spinner._update_spinner_msg("\n", stream=sys.stdout)
+        console_spinner._update_spinner_msg("\t", stream=sys.stdout)
+        console_spinner._update_spinner_msg("      ", stream=sys.stdout)
+        console_spinner._spinning_msg.stop()
+
+        stdout = capsys.readouterr().out
+        spin_and_final_line = "\r\x1b[2K⣾ test_6021..." + "\r\x1b[2Ktest_6021\n"
+        assert stdout == spin_and_final_line
 
 
 class Test_ThreadSafeInput:

--- a/cotainr/tests/tracing/test_console_spinner.py
+++ b/cotainr/tests/tracing/test_console_spinner.py
@@ -1,0 +1,86 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+import sys
+
+import pytest
+
+from cotainr.tracing import ConsoleSpinner, StreamWriteProxy
+from .stubs import RaiseOnEnterContext
+
+
+class TestConstructor:
+    def test_attributes(self):
+        spinner = ConsoleSpinner()
+        assert isinstance(spinner._stdout_proxy, StreamWriteProxy)
+        assert spinner._stdout_proxy._stream is sys.stdout
+        assert isinstance(spinner._stderr_proxy, StreamWriteProxy)
+        assert spinner._stderr_proxy._stream is sys.stderr
+        assert spinner._true_input_func is input
+        assert spinner._spinning_msg is None
+
+
+class TestContext:
+    def test_as_atomic_enter(self):
+        console_spinner = ConsoleSpinner()
+        console_spinner._as_atomic = RaiseOnEnterContext()
+        with pytest.raises(NotImplementedError, match=r"^Entered context$"):
+            console_spinner.__enter__()
+
+    def test_as_atomic_exit(self):
+        console_spinner = ConsoleSpinner()
+        console_spinner._as_atomic = RaiseOnEnterContext()
+        with pytest.raises(NotImplementedError, match=r"^Entered context$"):
+            console_spinner.__exit__(None, None, None)
+
+    def test_correctly_handling_input(self):
+        1 / 0
+
+    def test_correctly_spinning_stdout_msg(self):
+        1 / 0
+
+    def test_correctly_spinning_stderr_msg(self):
+        1 / 0
+
+    def test_exiting_context_with_spinning_msg(self):
+        1 / 0
+
+    def test_exiting_context_without_spinnnig_msg(self):
+        1 / 0
+
+    def test_reentering_context(self):
+        1 / 0
+
+
+class Test_UpdateSpinnerMsg:
+    def test_as_atomic(self):
+        console_spinner = ConsoleSpinner()
+        console_spinner._as_atomic = RaiseOnEnterContext()
+        with pytest.raises(NotImplementedError, match=r"^Entered context$"):
+            console_spinner._update_spinner_msg("", stream=None)
+
+    def test_first_message_correctly_started(self):
+        1 / 0
+
+    def test_message_correctly_updated(self):
+        1 / 0
+
+
+class Test_ThreadSafeInput:
+    def test_as_atomic(self):
+        console_spinner = ConsoleSpinner()
+        console_spinner._as_atomic = RaiseOnEnterContext()
+        wrapped_input_func = console_spinner._thread_safe_input(lambda: None)
+        with pytest.raises(NotImplementedError, match=r"^Entered context$"):
+            wrapped_input_func()
+
+    def test_stop_spinning_msg(self):
+        1 / 0
+
+    def test_wrap_input_func(self):
+        1 / 0

--- a/cotainr/tests/tracing/test_log_dispatcher.py
+++ b/cotainr/tests/tracing/test_log_dispatcher.py
@@ -335,12 +335,9 @@ class TestLogToStderr:
         [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL],
     )
     def test_log_to_correct_level(self, level, caplog):
-        def loc_level_func(msg):
-            return level
-
         log_dispatcher = LogDispatcher(
             name="test_dispatcher_6021",
-            map_log_level_func=loc_level_func,
+            map_log_level_func=lambda msg: level,
             log_settings=LogSettings(verbosity=3, log_file_path=None, no_color=True),
         )
         log_dispatcher.log_to_stderr("test_6021")
@@ -350,12 +347,9 @@ class TestLogToStderr:
         assert caplog.records[0].msg == "test_6021"
 
     def test_strip_whitespace(self, caplog):
-        def loc_level_func(msg):
-            return logging.INFO
-
         log_dispatcher = LogDispatcher(
             name="test_dispatcher_6021",
-            map_log_level_func=loc_level_func,
+            map_log_level_func=lambda msg: logging.INFO,
             log_settings=LogSettings(verbosity=1, log_file_path=None, no_color=True),
         )
         for msg in ["  before", "after  ", "  before and after  "]:
@@ -374,12 +368,9 @@ class TestLogToStdout:
         [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL],
     )
     def test_log_to_correct_level(self, level, caplog):
-        def loc_level_func(msg):
-            return level
-
         log_dispatcher = LogDispatcher(
             name="test_dispatcher_6021",
-            map_log_level_func=loc_level_func,
+            map_log_level_func=lambda msg: level,
             log_settings=LogSettings(verbosity=3, log_file_path=None, no_color=True),
         )
         log_dispatcher.log_to_stdout("test_6021")
@@ -389,12 +380,9 @@ class TestLogToStdout:
         assert caplog.records[0].msg == "test_6021"
 
     def test_strip_whitespace(self, caplog):
-        def loc_level_func(msg):
-            return logging.INFO
-
         log_dispatcher = LogDispatcher(
             name="test_dispatcher_6021",
-            map_log_level_func=loc_level_func,
+            map_log_level_func=lambda msg: logging.INFO,
             log_settings=LogSettings(verbosity=1, log_file_path=None, no_color=True),
         )
         for msg in ["  before", "after  ", "  before and after  "]:

--- a/cotainr/tests/tracing/test_log_dispatcher.py
+++ b/cotainr/tests/tracing/test_log_dispatcher.py
@@ -1,0 +1,111 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+
+import logging
+
+import pytest
+
+from cotainr.tracing import LogDispatcher, LogSettings
+
+
+class TestConstructor:
+    def test_attributes(self):
+        def loc_level_func(msg):
+            pass
+
+        log_settings = LogSettings()
+        log_dispatcher = LogDispatcher(
+            name="test_dispatcher_6021",
+            map_log_level_func=loc_level_func,
+            log_settings=log_settings,
+        )
+        assert log_dispatcher.map_log_level is loc_level_func
+        assert log_dispatcher.verbosity == log_settings.verbosity
+        assert log_dispatcher.log_file_path == log_settings.log_file_path
+        assert log_dispatcher.no_color == log_settings.no_color
+        assert log_dispatcher.logger_stdout.name == "test_dispatcher_6021.out"
+        assert log_dispatcher.logger_stderr.name == "test_dispatcher_6021.err"
+
+
+class TestLogToStderr:
+    @pytest.mark.parametrize(
+        "level",
+        [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL],
+    )
+    def test_log_to_correct_level(self, level, caplog):
+        def loc_level_func(msg):
+            return level
+
+        log_dispatcher = LogDispatcher(
+            name="test_dispatcher_6021",
+            map_log_level_func=loc_level_func,
+            log_settings=LogSettings(verbosity=3, log_file_path=None, no_color=True),
+        )
+        log_dispatcher.log_to_stderr("test_6021")
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == level
+        assert caplog.records[0].name == "test_dispatcher_6021.err"
+        assert caplog.records[0].msg == "test_6021"
+
+    def test_strip_whitespace(self, caplog):
+        def loc_level_func(msg):
+            return logging.INFO
+
+        log_dispatcher = LogDispatcher(
+            name="test_dispatcher_6021",
+            map_log_level_func=loc_level_func,
+            log_settings=LogSettings(verbosity=1, log_file_path=None, no_color=True),
+        )
+        for msg in ["  before", "after  ", "  before and after  "]:
+            log_dispatcher.log_to_stderr(msg=msg)
+
+        assert len(caplog.records) == 3
+        assert all(rec.name == "test_dispatcher_6021.err" for rec in caplog.records)
+        assert caplog.records[0].msg == "before"
+        assert caplog.records[1].msg == "after"
+        assert caplog.records[2].msg == "before and after"
+
+
+class TestLogToStdout:
+    @pytest.mark.parametrize(
+        "level",
+        [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL],
+    )
+    def test_log_to_correct_level(self, level, caplog):
+        def loc_level_func(msg):
+            return level
+
+        log_dispatcher = LogDispatcher(
+            name="test_dispatcher_6021",
+            map_log_level_func=loc_level_func,
+            log_settings=LogSettings(verbosity=3, log_file_path=None, no_color=True),
+        )
+        log_dispatcher.log_to_stdout("test_6021")
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == level
+        assert caplog.records[0].name == "test_dispatcher_6021.out"
+        assert caplog.records[0].msg == "test_6021"
+
+    def test_strip_whitespace(self, caplog):
+        def loc_level_func(msg):
+            return logging.INFO
+
+        log_dispatcher = LogDispatcher(
+            name="test_dispatcher_6021",
+            map_log_level_func=loc_level_func,
+            log_settings=LogSettings(verbosity=1, log_file_path=None, no_color=True),
+        )
+        for msg in ["  before", "after  ", "  before and after  "]:
+            log_dispatcher.log_to_stdout(msg=msg)
+
+        assert len(caplog.records) == 3
+        assert all(rec.name == "test_dispatcher_6021.out" for rec in caplog.records)
+        assert caplog.records[0].msg == "before"
+        assert caplog.records[1].msg == "after"
+        assert caplog.records[2].msg == "before and after"

--- a/cotainr/tests/tracing/test_log_dispatcher.py
+++ b/cotainr/tests/tracing/test_log_dispatcher.py
@@ -44,6 +44,29 @@ class TestConstructor:
 
         assert log_dispatcher.logger_stderr.name == "test_dispatcher_6021.err"
 
+    def test_adding_filters(self):
+        # Define test filters
+        class TestFilter1(logging.Filter):
+            pass
+
+        class TestFilter2(logging.Filter):
+            pass
+
+        filters = [TestFilter1(), TestFilter2()]
+
+        # Setup the LogDispatcher
+        log_dispatcher = LogDispatcher(
+            name="test_dispatcher_6021",
+            map_log_level_func=lambda msg: 0,  # not used in test since we log directly to loggers
+            log_settings=LogSettings(),
+            filters=filters,
+        )
+        for logger in [log_dispatcher.logger_stdout, log_dispatcher.logger_stderr]:
+            for handler in logger.handlers:
+                assert len(handler.filters) == 2
+                for handler_filter, test_filter in zip(handler.filters, filters):
+                    assert handler_filter is test_filter
+
     @pytest.mark.parametrize("verbosity", [-1, -2, -3, -5, -1000])
     def test_log_dispatcher_critical_logging(
         self,

--- a/cotainr/tests/tracing/test_log_dispatcher.py
+++ b/cotainr/tests/tracing/test_log_dispatcher.py
@@ -346,20 +346,19 @@ class TestLogToStderr:
         assert caplog.records[0].name == "test_dispatcher_6021.err"
         assert caplog.records[0].msg == "test_6021"
 
-    def test_strip_whitespace(self, caplog):
+    def test_not_stripping_whitespace(self, caplog):
         log_dispatcher = LogDispatcher(
             name="test_dispatcher_6021",
             map_log_level_func=lambda msg: logging.INFO,
             log_settings=LogSettings(verbosity=1, log_file_path=None, no_color=True),
         )
-        for msg in ["  before", "after  ", "  before and after  "]:
+        msgs = ["  before", "after  ", "  before and after  "]
+        for msg in msgs:
             log_dispatcher.log_to_stderr(msg=msg)
 
         assert len(caplog.records) == 3
         assert all(rec.name == "test_dispatcher_6021.err" for rec in caplog.records)
-        assert caplog.records[0].msg == "before"
-        assert caplog.records[1].msg == "after"
-        assert caplog.records[2].msg == "before and after"
+        assert all(msg == rec.msg for msg, rec in zip(msgs, caplog.records))
 
 
 class TestLogToStdout:
@@ -379,20 +378,19 @@ class TestLogToStdout:
         assert caplog.records[0].name == "test_dispatcher_6021.out"
         assert caplog.records[0].msg == "test_6021"
 
-    def test_strip_whitespace(self, caplog):
+    def test_not_stripping_whitespace(self, caplog):
         log_dispatcher = LogDispatcher(
             name="test_dispatcher_6021",
             map_log_level_func=lambda msg: logging.INFO,
             log_settings=LogSettings(verbosity=1, log_file_path=None, no_color=True),
         )
-        for msg in ["  before", "after  ", "  before and after  "]:
+        msgs = ["  before", "after  ", "  before and after  "]
+        for msg in msgs:
             log_dispatcher.log_to_stdout(msg=msg)
 
         assert len(caplog.records) == 3
         assert all(rec.name == "test_dispatcher_6021.out" for rec in caplog.records)
-        assert caplog.records[0].msg == "before"
-        assert caplog.records[1].msg == "after"
-        assert caplog.records[2].msg == "before and after"
+        assert all(msg == rec.msg for msg, rec in zip(msgs, caplog.records))
 
 
 class TestPrefixStderrName:

--- a/cotainr/tests/tracing/test_log_dispatcher.py
+++ b/cotainr/tests/tracing/test_log_dispatcher.py
@@ -7,11 +7,21 @@ Licensed under the European Union Public License (EUPL) 1.2
 
 """
 
+import itertools
 import logging
+import re
 
 import pytest
 
 from cotainr.tracing import LogDispatcher, LogSettings
+
+from .data import (
+    data_log_dispatcher_critical_color_log_messages,
+    data_log_dispatcher_debug_color_log_messages,
+    data_log_dispatcher_info_color_log_messages,
+    data_log_dispatcher_info_no_color_log_messages,
+    data_log_dispatcher_warning_color_log_messages,
+)
 
 
 class TestConstructor:
@@ -30,7 +40,293 @@ class TestConstructor:
         assert log_dispatcher.log_file_path == log_settings.log_file_path
         assert log_dispatcher.no_color == log_settings.no_color
         assert log_dispatcher.logger_stdout.name == "test_dispatcher_6021.out"
+
         assert log_dispatcher.logger_stderr.name == "test_dispatcher_6021.err"
+
+    @pytest.mark.parametrize("verbosity", [-1, -2, -3, -5, -1000])
+    def test_log_dispatcher_critical_logging(
+        self,
+        verbosity,
+        capsys,
+        data_log_dispatcher_critical_color_log_messages,
+    ):
+        (
+            logger_name,
+            log_level_msgs,
+            stdout_msgs,
+            stderr_msgs,
+        ) = data_log_dispatcher_critical_color_log_messages
+
+        # Setup the LogDispatcher
+        log_dispatcher = LogDispatcher(
+            name=logger_name,
+            map_log_level_func=lambda msg: 0,  # not used in test since we log directly to loggers
+            log_settings=LogSettings(
+                verbosity=verbosity, log_file_path=None, no_color=False
+            ),
+        )
+        assert f"{logger_name}.out" in logging.Logger.manager.loggerDict
+        assert f"{logger_name}.err" in logging.Logger.manager.loggerDict
+
+        # Log test messages to log dispatcher loggers
+        for logger in [log_dispatcher.logger_stdout, log_dispatcher.logger_stderr]:
+
+            # Log messages
+            for level, msg in log_level_msgs.items():
+                logger.log(level=level, msg=msg)
+
+            # Check correct log level
+            assert logger.getEffectiveLevel() == logging.CRITICAL
+
+            # Check correct handles
+            # Pytest manipulates the handler streams to capture the logging output
+            assert len(logger.handlers) == 1
+            assert isinstance(logger.handlers[0], logging.StreamHandler)
+
+        # Check correct logging, incl. message format, coloring, log level, and output stream
+        outerr = capsys.readouterr()  # readouterr clears its content when returning
+        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
+        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
+
+    @pytest.mark.parametrize("verbosity", [3, 4, 5, 1000])
+    def test_log_dispatcher_debug_logging(
+        self,
+        verbosity,
+        capsys,
+        data_log_dispatcher_debug_color_log_messages,
+    ):
+        (
+            logger_name,
+            log_level_msgs,
+            expected_stdout_msgs,
+            expected_stderr_msgs,
+        ) = data_log_dispatcher_debug_color_log_messages
+
+        # Setup the LogDispatcher
+        log_dispatcher = LogDispatcher(
+            name=logger_name,
+            map_log_level_func=lambda msg: 0,  # not used in test since we log directly to loggers
+            log_settings=LogSettings(
+                verbosity=verbosity, log_file_path=None, no_color=False
+            ),
+        )
+        assert f"{logger_name}.out" in logging.Logger.manager.loggerDict
+        assert f"{logger_name}.err" in logging.Logger.manager.loggerDict
+
+        # Log test messages to log dispatcher loggers
+        for logger in [log_dispatcher.logger_stdout, log_dispatcher.logger_stderr]:
+
+            # Log messages
+            for level, msg in log_level_msgs.items():
+                logger.log(level=level, msg=msg)
+
+            # Check correct log level
+            assert logger.getEffectiveLevel() == logging.DEBUG
+
+            # Check correct handles
+            # Pytest manipulates the handler streams to capture the logging output
+            assert len(logger.handlers) == 1
+            assert isinstance(logger.handlers[0], logging.StreamHandler)
+
+        # Check correct logging, incl. message format, coloring, log level, and output stream
+        outerr = capsys.readouterr()  # readouterr clears its content when returning
+        actual_stdout_msgs = outerr.out.rstrip("\n").split("\n")
+        actual_stderr_msgs = outerr.err.rstrip("\n").split("\n")
+        assert len(actual_stdout_msgs) == len(expected_stdout_msgs)
+        assert len(actual_stderr_msgs) == len(expected_stderr_msgs)
+        debug_msg_start_re = re.compile(
+            # Verbose debug msg prefix along lines of:
+            # 2023-09-27 10:39:07,763 -
+            r"^\d{4}(-\d{2}){2} (\d{2}:){2}\d{2},\d{3} - "
+        )
+        for actual_msg, expected_msg in itertools.chain(
+            zip(actual_stdout_msgs, expected_stdout_msgs),
+            zip(actual_stderr_msgs, expected_stderr_msgs),
+        ):
+            assert debug_msg_start_re.match(actual_msg)
+            assert actual_msg.endswith(expected_msg)
+
+    @pytest.mark.parametrize("verbosity", [1, 2])
+    def test_log_dispatcher_info_logging(
+        self,
+        verbosity,
+        capsys,
+        data_log_dispatcher_info_color_log_messages,
+    ):
+        (
+            logger_name,
+            log_level_msgs,
+            stdout_msgs,
+            stderr_msgs,
+        ) = data_log_dispatcher_info_color_log_messages
+
+        # Setup the LogDispatcher
+        log_dispatcher = LogDispatcher(
+            name=logger_name,
+            map_log_level_func=lambda msg: 0,  # not used in test since we log directly to loggers
+            log_settings=LogSettings(
+                verbosity=verbosity, log_file_path=None, no_color=False
+            ),
+        )
+        assert f"{logger_name}.out" in logging.Logger.manager.loggerDict
+        assert f"{logger_name}.err" in logging.Logger.manager.loggerDict
+
+        # Log test messages to log dispatcher loggers
+        for logger in [log_dispatcher.logger_stdout, log_dispatcher.logger_stderr]:
+
+            # Log messages
+            for level, msg in log_level_msgs.items():
+                logger.log(level=level, msg=msg)
+
+            # Check correct log level
+            assert logger.getEffectiveLevel() == logging.INFO
+
+            # Check correct handles
+            # Pytest manipulates the handler streams to capture the logging output
+            assert len(logger.handlers) == 1
+            assert isinstance(logger.handlers[0], logging.StreamHandler)
+
+        # Check correct logging, incl. message format, coloring, log level, and output stream
+        outerr = capsys.readouterr()  # readouterr clears its content when returning
+        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
+        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
+
+    def test_log_dispatcher_warning_logging(
+        self,
+        capsys,
+        data_log_dispatcher_warning_color_log_messages,
+    ):
+        verbosity = 0
+        (
+            logger_name,
+            log_level_msgs,
+            stdout_msgs,
+            stderr_msgs,
+        ) = data_log_dispatcher_warning_color_log_messages
+
+        # Setup the LogDispatcher
+        log_dispatcher = LogDispatcher(
+            name=logger_name,
+            map_log_level_func=lambda msg: 0,  # not used in test since we log directly to loggers
+            log_settings=LogSettings(
+                verbosity=verbosity, log_file_path=None, no_color=False
+            ),
+        )
+        assert f"{logger_name}.out" in logging.Logger.manager.loggerDict
+        assert f"{logger_name}.err" in logging.Logger.manager.loggerDict
+
+        # Log test messages to log dispatcher loggers
+        for logger in [log_dispatcher.logger_stdout, log_dispatcher.logger_stderr]:
+
+            # Log messages
+            for level, msg in log_level_msgs.items():
+                logger.log(level=level, msg=msg)
+
+            # Check correct log level
+            assert logger.getEffectiveLevel() == logging.WARNING
+
+            # Check correct handles
+            # Pytest manipulates the handler streams to capture the logging output
+            assert len(logger.handlers) == 1
+            assert isinstance(logger.handlers[0], logging.StreamHandler)
+
+        # Check correct logging, incl. message format, coloring, log level, and output stream
+        outerr = capsys.readouterr()  # readouterr clears its content when returning
+        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
+        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
+
+    @pytest.mark.parametrize("no_color", [True, False])
+    def test_log_to_file(
+        self,
+        no_color,
+        tmp_path,
+        data_log_dispatcher_info_no_color_log_messages,
+    ):
+        (
+            logger_name,
+            log_level_msgs,
+            stdout_msgs,
+            stderr_msgs,
+        ) = data_log_dispatcher_info_no_color_log_messages
+
+        # Setup the LogDispatcher
+        log_file_path = tmp_path / "cotainr_log"
+        log_dispatcher = LogDispatcher(
+            name=logger_name,
+            map_log_level_func=lambda msg: 0,  # not used in test since we log directly to loggers
+            log_settings=LogSettings(
+                verbosity=1, log_file_path=log_file_path, no_color=no_color
+            ),
+        )
+        assert f"{logger_name}.out" in logging.Logger.manager.loggerDict
+        assert f"{logger_name}.err" in logging.Logger.manager.loggerDict
+
+        # Log test messages to log dispatcher loggers
+        for logger in [log_dispatcher.logger_stdout, log_dispatcher.logger_stderr]:
+
+            # Log messages
+            for level, msg in log_level_msgs.items():
+                logger.log(level=level, msg=msg)
+
+            # Check correct log level
+            assert logger.getEffectiveLevel() == logging.INFO
+
+            # Check correct handles
+            # Pytest manipulates the handler streams to capture the logging output
+            assert len(logger.handlers) == 2
+            assert isinstance(logger.handlers[0], logging.StreamHandler)
+            assert isinstance(logger.handlers[1], logging.FileHandler)
+
+        # Check correct logging, incl. message format, coloring, log level to file
+        assert (
+            log_file_path.with_suffix(".out").read_text().rstrip("\n").split("\n")
+            == stdout_msgs
+        )
+        assert (
+            log_file_path.with_suffix(".err").read_text().rstrip("\n").split("\n")
+            == stderr_msgs
+        )
+
+    def test_no_color_on_console(
+        self,
+        capsys,
+        data_log_dispatcher_info_no_color_log_messages,
+    ):
+        (
+            logger_name,
+            log_level_msgs,
+            stdout_msgs,
+            stderr_msgs,
+        ) = data_log_dispatcher_info_no_color_log_messages
+
+        # Setup the LogDispatcher
+        log_dispatcher = LogDispatcher(
+            name=logger_name,
+            map_log_level_func=lambda msg: 0,  # not used in test since we log directly to loggers
+            log_settings=LogSettings(verbosity=1, log_file_path=None, no_color=True),
+        )
+        assert f"{logger_name}.out" in logging.Logger.manager.loggerDict
+        assert f"{logger_name}.err" in logging.Logger.manager.loggerDict
+
+        # Log test messages to log dispatcher loggers
+        for logger in [log_dispatcher.logger_stdout, log_dispatcher.logger_stderr]:
+
+            # Log messages
+            for level, msg in log_level_msgs.items():
+                logger.log(level=level, msg=msg)
+
+            # Check correct log level
+            assert logger.getEffectiveLevel() == logging.INFO
+
+            # Check correct handles
+            # Pytest manipulates the handler streams to capture the logging output
+            assert len(logger.handlers) == 1
+            assert isinstance(logger.handlers[0], logging.StreamHandler)
+
+        # Check correct logging, incl. message format, coloring, log level, and output stream
+        outerr = capsys.readouterr()  # readouterr clears its content when returning
+        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
+        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
 
 
 class TestLogToStderr:
@@ -109,3 +405,36 @@ class TestLogToStdout:
         assert caplog.records[0].msg == "before"
         assert caplog.records[1].msg == "after"
         assert caplog.records[2].msg == "before and after"
+
+
+class TestPrefixStderrName:
+    def test_context_prefix_changes(self, caplog):
+        log_dispatcher = LogDispatcher(
+            name="test_dispatcher_6021",
+            map_log_level_func=lambda msg: 0,  # not used in test since we log directly to loggers,
+            log_settings=LogSettings(verbosity=3, log_file_path=None, no_color=True),
+        )
+        with log_dispatcher.prefix_stderr_name(prefix="context_prefix_6021"):
+            log_dispatcher.logger_stderr.info("test_6021")
+
+        log_dispatcher.logger_stderr.info("test_6022")
+
+        assert len(caplog.records) == 2
+        assert caplog.records[0].name == "context_prefix_6021/test_dispatcher_6021.err"
+        assert caplog.records[1].name == "test_dispatcher_6021.err"
+
+
+class TestDetermineLogLevel:
+    @pytest.mark.parametrize(
+        ["verbosity", "log_level"],
+        [
+            (-1, logging.CRITICAL),
+            (0, logging.WARNING),
+            (1, logging.INFO),
+            (2, logging.INFO),
+            (3, logging.DEBUG),
+            (4, logging.DEBUG),
+        ],
+    )
+    def test_correct_mapping_of_defined_log_levels(self, verbosity, log_level):
+        assert LogDispatcher._determine_log_level(verbosity=verbosity) == log_level

--- a/cotainr/tests/tracing/test_log_dispatcher.py
+++ b/cotainr/tests/tracing/test_log_dispatcher.py
@@ -22,6 +22,7 @@ from .data import (
     data_log_dispatcher_info_no_color_log_messages,
     data_log_dispatcher_warning_color_log_messages,
 )
+from .stubs import AlwaysCompareFalse
 
 
 class TestConstructor:
@@ -414,13 +415,26 @@ class Test_DetermineLogLevel:
     @pytest.mark.parametrize(
         ["verbosity", "log_level"],
         [
+            (-1000, logging.CRITICAL),
+            (-2, logging.CRITICAL),
             (-1, logging.CRITICAL),
             (0, logging.WARNING),
             (1, logging.INFO),
             (2, logging.INFO),
             (3, logging.DEBUG),
             (4, logging.DEBUG),
+            (1000, logging.DEBUG),
         ],
     )
     def test_correct_mapping_of_defined_log_levels(self, verbosity, log_level):
         assert LogDispatcher._determine_log_level(verbosity=verbosity) == log_level
+
+    def test_error_on_not_equal_to_any_integer_but_comparable(self):
+        with pytest.raises(ValueError) as exc_info:
+            LogDispatcher._determine_log_level(verbosity=AlwaysCompareFalse())
+
+        assert str(exc_info.value) == (
+            "Somehow we ended up with a verbosity=AlwaysCompareFalseStub of "
+            "type(verbosity)=<class 'cotainr.tests.tracing.stubs.AlwaysCompareFalse'> "
+            "that does not compare well with integers."
+        )

--- a/cotainr/tests/tracing/test_log_dispatcher.py
+++ b/cotainr/tests/tracing/test_log_dispatcher.py
@@ -108,9 +108,9 @@ class TestConstructor:
             assert isinstance(logger.handlers[0], logging.StreamHandler)
 
         # Check correct logging, incl. message format, coloring, log level, and output stream
-        outerr = capsys.readouterr()  # readouterr clears its content when returning
-        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
-        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
+        stdout, stderr = capsys.readouterr()  # readouterr clears its content when returning
+        assert stdout.rstrip("\n").split("\n") == stdout_msgs
+        assert stderr.rstrip("\n").split("\n") == stderr_msgs
 
     @pytest.mark.parametrize("verbosity", [3, 4, 5, 1000])
     def test_log_dispatcher_debug_logging(
@@ -153,9 +153,9 @@ class TestConstructor:
             assert isinstance(logger.handlers[0], logging.StreamHandler)
 
         # Check correct logging, incl. message format, coloring, log level, and output stream
-        outerr = capsys.readouterr()  # readouterr clears its content when returning
-        actual_stdout_msgs = outerr.out.rstrip("\n").split("\n")
-        actual_stderr_msgs = outerr.err.rstrip("\n").split("\n")
+        stdout, stderr = capsys.readouterr()  # readouterr clears its content when returning
+        actual_stdout_msgs = stdout.rstrip("\n").split("\n")
+        actual_stderr_msgs = stderr.rstrip("\n").split("\n")
         assert len(actual_stdout_msgs) == len(expected_stdout_msgs)
         assert len(actual_stderr_msgs) == len(expected_stderr_msgs)
         debug_msg_start_re = re.compile(
@@ -211,9 +211,9 @@ class TestConstructor:
             assert isinstance(logger.handlers[0], logging.StreamHandler)
 
         # Check correct logging, incl. message format, coloring, log level, and output stream
-        outerr = capsys.readouterr()  # readouterr clears its content when returning
-        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
-        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
+        stdout, stderr = capsys.readouterr()  # readouterr clears its content when returning
+        assert stdout.rstrip("\n").split("\n") == stdout_msgs
+        assert stderr.rstrip("\n").split("\n") == stderr_msgs
 
     def test_log_dispatcher_warning_logging(
         self,
@@ -255,9 +255,9 @@ class TestConstructor:
             assert isinstance(logger.handlers[0], logging.StreamHandler)
 
         # Check correct logging, incl. message format, coloring, log level, and output stream
-        outerr = capsys.readouterr()  # readouterr clears its content when returning
-        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
-        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
+        stdout, stderr = capsys.readouterr()  # readouterr clears its content when returning
+        assert stdout.rstrip("\n").split("\n") == stdout_msgs
+        assert stderr.rstrip("\n").split("\n") == stderr_msgs
 
     @pytest.mark.parametrize("no_color", [True, False])
     def test_log_to_file(
@@ -348,9 +348,9 @@ class TestConstructor:
             assert isinstance(logger.handlers[0], logging.StreamHandler)
 
         # Check correct logging, incl. message format, coloring, log level, and output stream
-        outerr = capsys.readouterr()  # readouterr clears its content when returning
-        assert outerr.out.rstrip("\n").split("\n") == stdout_msgs
-        assert outerr.err.rstrip("\n").split("\n") == stderr_msgs
+        stdout, stderr = capsys.readouterr()  # readouterr clears its content when returning
+        assert stdout.rstrip("\n").split("\n") == stdout_msgs
+        assert stderr.rstrip("\n").split("\n") == stderr_msgs
 
 
 class TestLogToStderr:

--- a/cotainr/tests/tracing/test_log_dispatcher.py
+++ b/cotainr/tests/tracing/test_log_dispatcher.py
@@ -424,7 +424,7 @@ class TestPrefixStderrName:
         assert caplog.records[1].name == "test_dispatcher_6021.err"
 
 
-class TestDetermineLogLevel:
+class Test_DetermineLogLevel:
     @pytest.mark.parametrize(
         ["verbosity", "log_level"],
         [

--- a/cotainr/tests/tracing/test_log_settings.py
+++ b/cotainr/tests/tracing/test_log_settings.py
@@ -1,0 +1,32 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+
+import pathlib
+
+from cotainr.tracing import LogSettings
+
+
+class TestConstructor:
+    def test_correct_types_and_values(self):
+        log_settings = LogSettings(
+            verbosity=1, log_file_path="/some/path_6021", no_color=True
+        )
+        assert isinstance(log_settings.verbosity, int)
+        assert log_settings.verbosity == 1
+        assert isinstance(log_settings.log_file_path, pathlib.Path)
+        assert log_settings.log_file_path.parent.as_posix() == "/some"
+        assert log_settings.log_file_path.name == "path_6021"
+        assert isinstance(log_settings.no_color, bool)
+        assert log_settings.no_color
+
+    def test_default_values(self):
+        log_settings = LogSettings()
+        assert log_settings.verbosity == 0
+        assert log_settings.log_file_path is None
+        assert not log_settings.no_color

--- a/cotainr/tests/tracing/test_message_spinner.py
+++ b/cotainr/tests/tracing/test_message_spinner.py
@@ -1,0 +1,220 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+import io
+import shutil
+import time
+
+import pytest
+
+from cotainr.tracing import MessageSpinner
+from .stubs import FixedNumberOfSpinsEvent
+
+
+@pytest.fixture()
+def safe_MessageSpinner(msg, stream):
+    """
+    Setup a MessageSpinner and make sure to stop it during teardown.
+
+    The parameters `msg` and `stream` must be passed to the fixture using a
+    pytest parameterization.
+    """
+    safe_MessageSpinner = MessageSpinner(msg=msg, stream=stream)
+    yield safe_MessageSpinner
+    safe_MessageSpinner.stop()
+
+
+class TestStart:
+    @pytest.mark.parametrize(["msg", "stream"], [("test 6021", io.StringIO())])
+    def test_correct_start(self, msg, stream, safe_MessageSpinner):
+        assert not safe_MessageSpinner._running
+        assert not safe_MessageSpinner._spinner_thread.is_alive()
+        safe_MessageSpinner.start()
+        assert safe_MessageSpinner._running
+        assert safe_MessageSpinner._spinner_thread.is_alive()
+
+    @pytest.mark.parametrize(["msg", "stream"], [("test 6021", io.StringIO())])
+    def test_spinning_started(self, msg, stream, safe_MessageSpinner):
+        safe_MessageSpinner.start()
+        for _ in range(5):
+            # wait for something to be written to the stream
+            stream_msg = stream.getvalue()
+            if stream_msg:
+                break
+            else:
+                time.sleep(0.2)
+        else:
+            raise RuntimeError("No message seems to be spinning")
+
+        assert msg in stream_msg
+
+
+class TestStop:
+    @pytest.mark.parametrize(["msg", "stream"], [("test 6021", io.StringIO())])
+    def test_stop_before_having_started(self, msg, stream, safe_MessageSpinner):
+        assert not safe_MessageSpinner._running
+        assert not safe_MessageSpinner._spinner_thread.is_alive()
+        safe_MessageSpinner.stop()
+        assert not safe_MessageSpinner._running
+        assert not safe_MessageSpinner._spinner_thread.is_alive()
+
+    @pytest.mark.parametrize(["msg", "stream"], [("test 6021", io.StringIO())])
+    def test_stop_when_running(self, msg, stream, safe_MessageSpinner):
+        assert not safe_MessageSpinner._running
+        assert not safe_MessageSpinner._spinner_thread.is_alive()
+        safe_MessageSpinner.start()
+        assert safe_MessageSpinner._running
+        assert safe_MessageSpinner._spinner_thread.is_alive()
+        safe_MessageSpinner.stop()
+        assert not safe_MessageSpinner._running
+        assert not safe_MessageSpinner._spinner_thread.is_alive()
+
+
+class Test_SpinMsg:
+    @pytest.mark.parametrize(
+        ["msg", "stream", "no_ansi_msg"],
+        [
+            (
+                # non SGR escape codes
+                "\033[Asome_long\x1b[A_message_w\x1b[2;Eith_a_\x1b[5;3;Hlot_of_"
+                "AN\x1b[KSI_codes_\x1b[B6021",
+                io.StringIO(),
+                "some_long_message_with_a_lot_of_ANSI_codes_6021",
+            ),
+            (
+                # "message_with_SGRs"
+                "\x1b[38;5;8mmess\x1b[38;5;8mage_with\x1b[38;5;1m_\x1b[38;5;160mSGRs"
+                "\x1b[0m",
+                io.StringIO(),
+                "\x1b[38;5;8mmess\x1b[38;5;8mage_with\x1b[38;5;1m_\x1b[38;5;160mSGRs"
+                "\x1b[0m",
+            ),
+        ],
+    )
+    def test_ansi_escape_codes_removal(
+        self, msg, stream, no_ansi_msg, safe_MessageSpinner, monkeypatch
+    ):
+        monkeypatch.setattr(
+            safe_MessageSpinner, "_stop_signal", FixedNumberOfSpinsEvent(spins=0)
+        )
+        # stop signal event patch no spin
+        safe_MessageSpinner._spin_msg()
+        stream_msg = (
+            stream.getvalue()
+            .removeprefix(safe_MessageSpinner._clear_line_code)
+            .rstrip("\n")
+        )
+        assert stream_msg == no_ansi_msg
+
+    @pytest.mark.parametrize(
+        ["msg", "stream", "no_newline_msg"],
+        [
+            ("test 6021\n", io.StringIO(), "test 6021"),
+            ("test 6021\n\n", io.StringIO(), "test 6021"),
+            ("\ntest\n 60\n21", io.StringIO(), "\ntest\n 60\n21"),
+            ("\ntest\n 60\n21\n", io.StringIO(), "\ntest\n 60\n21"),
+            (
+                "\x1b[38;5;8mtest 6021\x1b[0m\n",
+                io.StringIO(),
+                "\x1b[38;5;8mtest 6021\x1b[0m",
+            ),
+            (
+                "\x1b[38;5;8mtest 6021\n\x1b[0m",
+                io.StringIO(),
+                "\x1b[38;5;8mtest 6021\x1b[0m",
+            ),
+            (
+                "\x1b[38;5;8mtest 6021\n\n\x1b[0m",
+                io.StringIO(),
+                "\x1b[38;5;8mtest 6021\x1b[0m",
+            ),
+            (
+                "\n\x1b[38;5;8m\ntest 60\n21\n\n\x1b[0m",
+                io.StringIO(),
+                "\n\x1b[38;5;8m\ntest 60\n21\x1b[0m",
+            ),
+        ],
+    )
+    def test_newline_at_end_removal(
+        self, msg, stream, no_newline_msg, safe_MessageSpinner, monkeypatch
+    ):
+        monkeypatch.setattr(
+            safe_MessageSpinner, "_stop_signal", FixedNumberOfSpinsEvent(spins=0)
+        )
+        safe_MessageSpinner._spin_msg()
+        stream_msg = (
+            stream.getvalue()
+            .removeprefix(safe_MessageSpinner._clear_line_code)
+            .rstrip("\n")
+        )
+        assert stream_msg == no_newline_msg
+
+    @pytest.mark.parametrize(["msg", "stream"], [("test 6021", io.StringIO())])
+    def test_spinner_cycle(self, msg, stream, safe_MessageSpinner, monkeypatch):
+        monkeypatch.setattr(
+            safe_MessageSpinner,
+            "_stop_signal",
+            FixedNumberOfSpinsEvent(spins=16),  # Two full cycles
+        )
+        expected_spin_output = (
+            "\r\x1b[2K⣾ test 6021..."
+            "\r\x1b[2K⣷ test 6021..."
+            "\r\x1b[2K⣯ test 6021..."
+            "\r\x1b[2K⣟ test 6021..."
+            "\r\x1b[2K⡿ test 6021..."
+            "\r\x1b[2K⢿ test 6021..."
+            "\r\x1b[2K⣻ test 6021..."
+            "\r\x1b[2K⣽ test 6021..."
+        ) * 2 + "\r\x1b[2Ktest 6021\n"
+        safe_MessageSpinner._spin_msg()
+        stream_msg = stream.getvalue()
+        assert stream_msg == expected_spin_output
+
+    @pytest.mark.parametrize(
+        ["msg", "stream"],
+        [
+            (
+                "some_message_longer_than_terminal_width"
+                + "!" * shutil.get_terminal_size()[0],
+                io.StringIO(),
+            )
+        ],
+    )
+    def test_one_line_msg(self, msg, stream, safe_MessageSpinner, monkeypatch):
+        monkeypatch.setattr(
+            safe_MessageSpinner, "_stop_signal", FixedNumberOfSpinsEvent(spins=1)
+        )
+        exclamation_marks = shutil.get_terminal_size()[0] - len(
+            "⣾ some_message_longer_than_terminal_width..."
+        )
+        expected_one_line_msg = (
+            f"⣾ some_message_longer_than_terminal_width{'!'*exclamation_marks}..."
+        )
+        safe_MessageSpinner._spin_msg()
+        one_line_stream_msg = stream.getvalue().split("\r\x1b[2K")[1]
+        assert one_line_stream_msg == expected_one_line_msg
+
+    @pytest.mark.parametrize(
+        ["msg", "stream"],
+        [
+            (
+                "some_message_longer_than_terminal_width"
+                + "!" * shutil.get_terminal_size()[0],
+                io.StringIO(),
+            )
+        ],
+    )
+    def test_print_final_full_message(
+        self, msg, stream, safe_MessageSpinner, monkeypatch
+    ):
+        monkeypatch.setattr(
+            safe_MessageSpinner, "_stop_signal", FixedNumberOfSpinsEvent(spins=1)
+        )
+        safe_MessageSpinner._spin_msg()
+        final_stream_msg = stream.getvalue().split("\r\x1b[2K")[-1]
+        assert final_stream_msg == msg + "\n"

--- a/cotainr/tests/tracing/test_stream_write_proxy.py
+++ b/cotainr/tests/tracing/test_stream_write_proxy.py
@@ -1,0 +1,55 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+import io
+
+import pytest
+
+from cotainr.tracing import StreamWriteProxy
+
+
+class TestConstructor:
+    def test_attributes(self):
+        stream = io.StringIO()
+        stream_write_proxy = StreamWriteProxy(stream=stream)
+        assert stream_write_proxy._stream is stream
+        assert stream_write_proxy.true_stream_write == stream.write
+
+
+class TestWrite:
+    def test_write_when_stream_write_changed(self):
+        stream = io.StringIO()
+        stream_write_proxy = StreamWriteProxy(stream=stream)
+        stream.write = lambda s: ""
+        stream.write("some text to disappear ")
+        stream_write_proxy.write("some text to keep")
+        assert stream.getvalue() == "some text to keep"
+
+    def test_write_when_stream_write_unchanged(self):
+        stream = io.StringIO()
+        stream_write_proxy = StreamWriteProxy(stream=stream)
+        stream.write("some text to keep - ")
+        stream_write_proxy.write("some text to keep")
+        assert stream.getvalue() == "some text to keep - some text to keep"
+
+
+class TestGetAttr:
+    def test_failing_attribute_lookup_delegation(self):
+        stream = io.StringIO("some text 6021")
+        stream_write_proxy = StreamWriteProxy(stream=stream)
+        with pytest.raises(
+            AttributeError,
+            match=r"StringIO' object has no attribute 'some_nonsense_attribute_6021'$",
+        ):
+            stream_write_proxy.some_nonsense_attribute_6021
+
+    def test_successful_attribute_lookup_delegation(self):
+        stream = io.StringIO("some text 6021")
+        stream_write_proxy = StreamWriteProxy(stream=stream)
+        assert "getvalue" not in dir(stream_write_proxy)
+        assert stream_write_proxy.getvalue() == "some text 6021"

--- a/cotainr/tests/util/patches.py
+++ b/cotainr/tests/util/patches.py
@@ -20,12 +20,15 @@ def patch_disable_stream_subprocess(monkeypatch):
     """
     Disable stream_subprocess(...).
 
-    The `stream_subprocess` function is replaced by a mock that prints and
-    returns a message about the process that would have been run.
+    The `stream_subprocess` function is replaced by a mock that prints to
+    stdout, logs to stderr (if a log_dispatcher is provided), and returns a
+    message about the process that would have been run.
     """
 
-    def mock_stream_subprocess(args, **kwargs):
+    def mock_stream_subprocess(*, args, log_dispatcher, **kwargs):
         msg = f"PATCH: Streamed subprocess: {args=}, {kwargs=}"
+        if log_dispatcher is not None:
+            log_dispatcher.log_to_stderr(msg)
         print(msg)
         return msg
 

--- a/cotainr/tests/util/test_get_systems.py
+++ b/cotainr/tests/util/test_get_systems.py
@@ -7,8 +7,6 @@ Licensed under the European Union Public License (EUPL) 1.2
 
 """
 
-from typing import Dict
-
 import pytest
 from .patches import (
     patch_empty_system,
@@ -23,19 +21,19 @@ class TestGetSystems:
     def test_non_existing(self, patch_system_with_non_existing_file):
         systems = cotainr.util.get_systems()
 
-        assert isinstance(systems, Dict)
+        assert isinstance(systems, dict)
         assert not systems
 
     def test_non_empty(self, patch_empty_system):
         systems = cotainr.util.get_systems()
 
-        assert isinstance(systems, Dict)
+        assert isinstance(systems, dict)
         assert not systems
 
     def test_actual_file(self, patch_system_with_actual_file):
         systems = cotainr.util.get_systems()
 
-        assert isinstance(systems, Dict)
+        assert isinstance(systems, dict)
         assert len(systems) == 2
         assert list(systems.keys())[0].startswith("some")
         assert list(systems.keys())[1].startswith("another")

--- a/cotainr/tests/util/test_stream_subprocess.py
+++ b/cotainr/tests/util/test_stream_subprocess.py
@@ -7,6 +7,7 @@ Licensed under the European Union Public License (EUPL) 1.2
 
 """
 
+import functools
 import io
 import platform
 import subprocess
@@ -83,7 +84,10 @@ class Test_PrintAndCaptureStream:
     def test_print_stdout_roundtrip(self, capsys):
         stdout_lines = ["Test line 1", "Test line 2", "Test line 3"]
         input_stream = io.StringIO("\n".join(stdout_lines))
-        _print_and_capture_stream(stream_handle=input_stream, print_stream=sys.stdout)
+        print_dispatch = functools.partial(print, end="", file=sys.stdout)
+        _print_and_capture_stream(
+            stream_handle=input_stream, print_dispatch=print_dispatch
+        )
         captured_io = capsys.readouterr()
         assert captured_io.out.split("\n") == stdout_lines
 
@@ -91,7 +95,8 @@ class Test_PrintAndCaptureStream:
         input_text = "Test line 1\nTest line 2"
         input_stream = io.StringIO(input_text)
         output_stream = io.StringIO()
+        print_dispatch = functools.partial(print, end="", file=output_stream)
         captured_stream = _print_and_capture_stream(
-            stream_handle=input_stream, print_stream=output_stream
+            stream_handle=input_stream, print_dispatch=print_dispatch
         )
         assert output_stream.getvalue() == "".join(captured_stream)

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -62,7 +62,7 @@ class ColoredOutputFormatter(logging.Formatter):
     log_level_fg_colors = {
         # https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
         logging.DEBUG: "\x1b[38;5;8m",  # gray
-        logging.INFO: "", # no special color
+        logging.INFO: "",  # no special color
         logging.WARNING: "\x1b[38;5;3m",  # yellow
         logging.ERROR: "\x1b[38;5;1m",  # dark red
         logging.CRITICAL: "\x1b[38;5;160m",  # brighter red
@@ -289,20 +289,6 @@ class LogDispatcher:
             self.logger_stderr.handlers,
         )
 
-    def log_to_stdout(self, msg):
-        """
-        Log a message to `stdout`.
-
-        Determines the log level based on the `map_log_level` function and logs
-        the `msg` to `stdout` using that log level.
-
-        Parameters
-        ----------
-        msg : str
-            The message to log.
-        """
-        self.logger_stdout.log(level=self.map_log_level(msg), msg=msg.strip())
-
     def log_to_stderr(self, msg):
         """
         Log a message to `stderr`.
@@ -316,6 +302,20 @@ class LogDispatcher:
             The message to log.
         """
         self.logger_stderr.log(level=self.map_log_level(msg), msg=msg.strip())
+
+    def log_to_stdout(self, msg):
+        """
+        Log a message to `stdout`.
+
+        Determines the log level based on the `map_log_level` function and logs
+        the `msg` to `stdout` using that log level.
+
+        Parameters
+        ----------
+        msg : str
+            The message to log.
+        """
+        self.logger_stdout.log(level=self.map_log_level(msg), msg=msg.strip())
 
     @contextlib.contextmanager
     def prefix_stderr_name(self, *, prefix):

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -174,6 +174,7 @@ class MessageSpinner:
         self._spinner_cycle = itertools.cycle("⣾⣷⣯⣟⡿⢿⣻⣽")
         self._spinner_thread = threading.Thread(target=self._spin_msg)
         self._spinner_sleep_interval = 0.1
+        self._spinner_delay_time = 0.025
         self._stop_signal = threading.Event()
         self._print_width = (
             # account for leading spinner + whitespace (2 chars)
@@ -209,7 +210,7 @@ class MessageSpinner:
     def _spin_msg(self):
         # Delay spinning a bit to avoid flaky message updates when new messages
         # arrive promptly
-        time.sleep(self._spinner_sleep_interval / 4)
+        time.sleep(self._spinner_delay_time)
 
         # Strip any newlines and ANSI escape codes that may interfere with
         # our manipulation of the console (not SGRs, though)

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -1,3 +1,18 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+This module implements utility functions.
+
+Classes
+-------
+ColoredOutputFormatter(logging.Formatter)
+    A log formatter for coloring log messages based on log level.
+
+"""
 import copy
 import contextlib
 import dataclasses
@@ -16,6 +31,17 @@ logger = logging.getLogger(__name__)
 
 
 class ColoredOutputFormatter(logging.Formatter):
+    """
+    A log formatter for coloring log messages based on log level.
+
+    Inserts ANSI escape codes to color lines based on their log level:
+
+    - logging.DEBUG : gray
+    - logging.WARNING : yellow
+    - logging.ERROR : dark read
+    - logging.CRITICAL : brighter red
+    """
+
     log_level_fg_colors = {
         # https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
         logging.DEBUG: "\x1b[38;5;8m",  # gray
@@ -26,6 +52,7 @@ class ColoredOutputFormatter(logging.Formatter):
     reset_color = "\x1b[0m"
 
     def format(self, record):
+        """Format the specified record as colored text."""
         fg_color = self.log_level_fg_colors.get(record.levelno, "")
         if fg_color:
             color_record = copy.copy(record)

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -13,14 +13,14 @@ ColoredOutputFormatter(logging.Formatter)
     A log formatter for coloring log messages based on log level.
 ConsoleSpinner
     A console messages spinner context manager.
-StreamWriteProxy
-    A proxy for manipulating the write methods of streams.
 LogDispatcher
     A dispatcher for configuring and handling log messages.
 LogSettings
     Dataclass containing settings for a LogDispatcher.
 MessageSpinner
     A spinner for console messages.
+StreamWriteProxy
+    A proxy for manipulating the write methods of streams.
 """
 import builtins
 import copy
@@ -110,6 +110,13 @@ class ConsoleSpinner:
 
     The :py:func:`input` function is wrapped to make sure that the spinner is
     stopped while waiting for the user to provide their input.
+
+    As we only ever have a single console which we are interacting with via
+    stdin/stdout/stderr, it makes sense to have a single corresponding
+    ConsoleSpinner. We keep track of this single instance via the global
+    variable cotainr.tracing._within_console_spinner_context which is a bit
+    unclean, but a lot easier than trying to keep track of the number of times
+    we have entered a ConsoleSpinner context.
 
     Nothing is done to handle the use of the :py:mod:`readline` module. It may
     or may not work in a :class:`ConsoleSpinner` context.

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 import threading
 import time
+import typing
 
 logger = logging.getLogger(__name__)
 
@@ -161,7 +162,7 @@ class LogDispatcher:
 @dataclasses.dataclass
 class LogSettings:
     verbosity: int = 0
-    log_file_path: pathlib.Path | None = None
+    log_file_path: typing.Optional[pathlib.Path] = None
     no_color: bool = False
 
 

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -242,8 +242,8 @@ class LogDispatcher:
         log_level = self._determine_log_level(verbosity=log_settings.verbosity)
 
         # Setup cotainr log format
-        if self.verbosity >= 2:
-            log_fmt = "%(asctime)s - %(name)s:%(levelname)s %(message)s"
+        if self.verbosity >= 3:
+            log_fmt = "%(asctime)s - %(name)s:-:%(levelname)s: %(message)s"
         else:
             log_fmt = "%(name)s:-: %(message)s"
 
@@ -351,7 +351,7 @@ class LogDispatcher:
             One of the standard log levels (DEBUG, INFO, WARNING, ERROR, or
             CRITICAL).
         """
-        if verbosity == -1:
+        if verbosity <= -1:
             log_level = logging.CRITICAL
         elif verbosity == 0:
             log_level = logging.WARNING

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -62,6 +62,7 @@ class ColoredOutputFormatter(logging.Formatter):
     log_level_fg_colors = {
         # https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
         logging.DEBUG: "\x1b[38;5;8m",  # gray
+        logging.INFO: "", # no special color
         logging.WARNING: "\x1b[38;5;3m",  # yellow
         logging.ERROR: "\x1b[38;5;1m",  # dark red
         logging.CRITICAL: "\x1b[38;5;160m",  # brighter red

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -253,10 +253,14 @@ class LogDispatcher:
 
         if self.log_file_path is not None:
             stdout_handlers.append(
-                logging.FileHandler(self.log_file_path.with_suffix(".out"))
+                logging.FileHandler(
+                    self.log_file_path.with_suffix(self.log_file_path.suffix + ".out")
+                )
             )
             stderr_handlers.append(
-                logging.FileHandler(self.log_file_path.with_suffix(".err"))
+                logging.FileHandler(
+                    self.log_file_path.with_suffix(self.log_file_path.suffix + ".err")
+                )
             )
         for handler in stdout_handlers + stderr_handlers:
             handler.setLevel(log_level)

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -359,10 +359,17 @@ class LogDispatcher:
             log_level = logging.CRITICAL
         elif verbosity == 0:
             log_level = logging.WARNING
-        elif verbosity in [1, 2]:
+        elif verbosity == 1 or verbosity == 2:
             log_level = logging.INFO
         elif verbosity >= 3:
             log_level = logging.DEBUG
+        else:
+            # This should not happen, but if you somehow specify e.g.
+            # verbosity=numpy.NaN, you will end up here...
+            raise ValueError(
+                f"Somehow we ended up with a {verbosity=} of {type(verbosity)=} "
+                "that does not compare well with integers."
+            )
 
         return log_level
 

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -1,0 +1,77 @@
+import logging
+import sys
+
+
+class ProgressHandler:
+    # TODO: Add consistent spinner...
+    stdout = sys.stdout
+    stderr = sys.stderr
+
+
+console_progress_handler = ProgressHandler()
+
+
+def get_cotainr_log_level(verbosity=None):
+    # TODO: Include this in LogDispatcher?
+    if verbosity == -1:
+        level = logging.CRITICAL  # TODO
+    elif verbosity == 0:
+        level = logging.NOTSET  # TODO: custom cotainr level?
+    elif verbosity == 1:
+        level = logging.INFO
+    elif verbosity >= 2:
+        level = logging.DEBUG
+
+    return level
+
+
+class LogDispatcher:
+    # TODO: Cleanup and document
+    def __init__(
+        self,
+        *,
+        name,
+        map_log_level_func,
+        verbosity
+    ):
+        log_level = get_cotainr_log_level(verbosity=verbosity)
+
+        console_log_formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )  # TODO: set based on CLI args
+        console_stdout_handler = logging.StreamHandler(stream=console_progress_handler.stdout)
+        console_stdout_handler.setLevel(log_level)
+        console_stdout_handler.setFormatter(console_log_formatter)
+        console_stderr_handler = logging.StreamHandler(stream=console_progress_handler.stderr)
+        console_stderr_handler.setLevel(log_level)
+        console_stderr_handler.setFormatter(console_log_formatter)
+
+        self.logger_stdout = logging.getLogger(f"{name}.stdout")
+        self.logger_stdout.addHandler(console_stdout_handler)
+        self.logger_stdout.setLevel(log_level)
+        self.logger_stderr = logging.getLogger(f"{name}.stderr")
+        self.logger_stderr.addHandler(console_stderr_handler)
+        self.logger_stderr.setLevel(log_level)
+        self.map_log_level = map_log_level_func
+
+    def log_to_stdout(self, msg):
+        self.logger_stdout.log(level=self.map_log_level(msg), msg=msg.strip())
+
+    def log_to_stderr(self, msg):
+        self.logger_stderr.log(level=self.map_log_level(msg), msg=msg.strip())
+
+
+def setup_log_handlers(*, verbosity=None):
+    # Setup logging
+    # TODO: Fully remove this?
+    console_log_formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )  # TODO: set based on CLI args
+    console_stdout_handler = logging.StreamHandler(stream=console_progress_handler.stdout)
+    console_stdout_handler.setLevel(logging.DEBUG)  # TODO: set based on CLI args
+    console_stdout_handler.setFormatter(console_log_formatter)
+    console_stderr_handler = logging.StreamHandler(stream=console_progress_handler.stderr)
+    console_stderr_handler.setLevel(logging.DEBUG)  # TODO: set based on CLI args
+    console_stderr_handler.setFormatter(console_log_formatter)
+    # TODO: Add FileHandler(s)
+

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -1,14 +1,123 @@
+import collections
+import itertools
 import logging
+import queue
+import shutil
 import sys
+import threading
+import time
+
+io_lock = threading.Lock()
+console_msg_queue = queue.Queue()  # TODO: handle global
+
+
+class QueuedStreamHandler(logging.Handler):
+    """
+    A handler class which writes logging records, appropriately formatted,
+    to a queue.
+    """
+
+    def __init__(self, stream=None):
+        """
+        Initialize the handler.
+        """
+        super().__init__()
+        if stream is None:
+            stream = sys.stderr
+        self.queue = console_msg_queue
+        self.stream = stream
+        self.StreamMsg = collections.namedtuple("StreamMsg", ["msg", "stream"])
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        If a formatter is specified, it is used to format the record.
+        The record is then written to the stream with a trailing newline.  If
+        exception information is present, it is formatted using
+        traceback.print_exception and appended to the stream.  If the stream
+        has an 'encoding' attribute, it is used to determine how to do the
+        output to the stream.
+        """
+
+        try:
+            msg = self.format(record)
+            self.queue.put(self.StreamMsg(msg=msg, stream=self.stream))
+        except Exception:
+            self.handleError(record)
 
 
 class ProgressHandler:
-    # TODO: Add consistent spinner...
-    stdout = sys.stdout
-    stderr = sys.stderr
+    def __init__(self):
+        """Construct the progress handler"""
+        self._queue = console_msg_queue  # TODO: handle global
+        self._spinner_cycle = itertools.cycle("⣾⣷⣯⣟⡿⢿⣻⣽")
+        self._spinner_thread = threading.Thread(target=self._spinner_run_sequence)
+        self._stop = threading.Event()
+        self._sleep_interval = 0.1
+        self._print_width = shutil.get_terminal_size()[0] - 2
+
+    def start(self):
+        """
+        Start the process of printing out the latest message.
+        It will run until the stop function is being called.
+        """
+        self._spinner_thread.start()
+
+    def _spinner_run_sequence(self):
+        current_item = None
+        while not self._stop.is_set() and current_item is None:
+            # Poll for first SteamMsg on queue
+            try:
+                current_item = self._queue.get_nowait()
+            except queue.Empty:
+                pass
+
+            time.sleep(self._sleep_interval)
+
+        while not self._stop.is_set():
+            # Check for new SteamMsg
+            try:
+                new_item = self._queue.get_nowait()
+                with io_lock:
+                    # Print old StreamMsg
+                    # \033[2K erases the old line to avoid the extra two
+                    # characters at the end of the line stemming from the shift
+                    # of the line due to the spinner character and a whitespace
+                    print(
+                        f"\033[2K{current_item.msg}",
+                        file=current_item.stream,
+                        flush=True,
+                    )
+                current_item = new_item
+            except queue.Empty:
+                pass
+
+            # Update spinner
+            with io_lock:
+                print(
+                    f"{next(self._spinner_cycle)} {current_item.msg[:self._print_width]}",
+                    end="\r",
+                    file=current_item.stream,
+                    flush=True,
+                )
+
+            time.sleep(self._sleep_interval)
+
+        if current_item is not None:
+            # Print final StreamMsg (if any arrived)
+            with io_lock:
+                print(
+                    f"\033[2K{current_item.msg}", file=current_item.stream, flush=True)
+
+    def stop(self):
+        """Stop the printing process"""
+        self._stop.set()
+        self._spinner_thread.join()
 
 
 console_progress_handler = ProgressHandler()
+console_progress_handler.start() # TODO
 
 
 class LogDispatcher:
@@ -25,14 +134,10 @@ class LogDispatcher:
             console_log_formatter = logging.Formatter(f"{name}$ %(message)s")
 
         # Setup log handlers
-        console_stdout_handler = logging.StreamHandler(
-            stream=console_progress_handler.stdout
-        )
+        console_stdout_handler = QueuedStreamHandler(stream=sys.stdout)
         console_stdout_handler.setLevel(log_level)
         console_stdout_handler.setFormatter(console_log_formatter)
-        console_stderr_handler = logging.StreamHandler(
-            stream=console_progress_handler.stderr
-        )
+        console_stderr_handler = QueuedStreamHandler(stream=sys.stderr)
         console_stderr_handler.setLevel(log_level)
         console_stderr_handler.setFormatter(console_log_formatter)
 

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -454,7 +454,7 @@ class MessageSpinner:
         self._newline_at_end_re = re.compile(
             # Find newlines at the end of a string even if the string is
             # wrapped in a set of SGR codes.
-            r"\n(?=(?:\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*m))+$|$)"
+            r"\n+(?=(?:\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*m))+$|$)"
         )
         self._running = False
 

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -2,9 +2,6 @@ import logging
 import sys
 
 
-COTAINR_CLI_INFO = 25
-
-
 class ProgressHandler:
     # TODO: Add consistent spinner...
     stdout = sys.stdout
@@ -14,34 +11,18 @@ class ProgressHandler:
 console_progress_handler = ProgressHandler()
 
 
-def get_cotainr_log_level(verbosity=None):
-    # TODO: Include this in LogDispatcher?
-    if verbosity == -1:
-        level = logging.CRITICAL
-    elif verbosity == 0:
-        level = logging.NOTSET
-    elif verbosity == 1:
-        level = logging.INFO
-    elif verbosity >= 2:
-        level = logging.DEBUG
-
-    return level
-
-
 class LogDispatcher:
     # TODO: Cleanup and document
     def __init__(self, *, name, map_log_level_func, verbosity):
-        log_level = get_cotainr_log_level(verbosity=verbosity)
+        log_level = self._determine_log_level(verbosity=verbosity)
 
         # Setup cotainr log format
         if verbosity >= 2:
             console_log_formatter = logging.Formatter(
-                f"%(asctime)s - %(name)s:%(levelname)s$ %(message)s"
+                "%(asctime)s - %(name)s:%(levelname)s$ %(message)s"
             )
         else:
-            console_log_formatter = logging.Formatter(
-                f"{name}$ %(message)s"
-            )
+            console_log_formatter = logging.Formatter(f"{name}$ %(message)s")
 
         # Setup log handlers
         console_stdout_handler = logging.StreamHandler(
@@ -70,34 +51,15 @@ class LogDispatcher:
     def log_to_stderr(self, msg):
         self.logger_stderr.log(level=self.map_log_level(msg), msg=msg.strip())
 
+    @staticmethod
+    def _determine_log_level(*, verbosity):
+        if verbosity == -1:
+            log_level = logging.CRITICAL
+        elif verbosity == 0:
+            log_level = logging.WARNING
+        elif verbosity == 1:
+            log_level = logging.INFO
+        elif verbosity >= 2:
+            log_level = logging.DEBUG
 
-def setup_cotainr_cli_logging(*, verbosity):
-    #TODO: Move to CotainrCLI?
-    if verbosity == 0:
-        cotainr_log_level = COTAINR_CLI_INFO
-    else:
-        cotainr_log_level = get_cotainr_log_level(verbosity=verbosity)
-
-    # Setup cotainr CLI log format
-    if verbosity >= 2:
-        cotainr_console_log_formatter = logging.Formatter(
-            "%(asctime)s - %(name)s::%(funcName)s::%(lineno)d::"
-            "Cotainr:%(levelname)s$ %(message)s"
-        )
-    else:
-        cotainr_console_log_formatter = logging.Formatter(
-            "Cotainr: %(message)s$"
-        )
-
-    # Setup cotainr CLI log handlers
-    cotainr_console_handler = logging.StreamHandler(
-        stream=console_progress_handler.stdout
-    )
-    cotainr_console_handler.setLevel(cotainr_log_level)
-    cotainr_console_handler.setFormatter(cotainr_console_log_formatter)
-
-    # Define cotainr root logger
-    root_logger = logging.getLogger("cotainr")
-    root_logger.setLevel(cotainr_log_level)
-    root_logger.addHandler(cotainr_console_handler)  # Cotainr logs to stdout
-    # TODO: Add FileHandler
+        return log_level

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -394,6 +394,13 @@ class LogSettings:
     log_file_path: typing.Optional[pathlib.Path] = None
     no_color: bool = False
 
+    def __post_init__(self):
+        """Cast fields to their expected types."""
+        self.verbosity = int(self.verbosity)
+        if self.log_file_path is not None:
+            self.log_file_path = pathlib.Path(self.log_file_path)
+        self.no_color = bool(self.no_color)
+
 
 class MessageSpinner:
     """

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -66,9 +66,9 @@ class ColoredOutputFormatter(logging.Formatter):
 class ConsoleSpinner:
     def __init__(self):
         # TODO: DOC: Modify true sys.std* to allow for context change at any point in time
-        self._stdout_proxy = StreamWriteProxy(stream=sys.stdout)  # TODO: consider just wrapping stream.write
+        self._stdout_proxy = StreamWriteProxy(stream=sys.stdout)
         self._stderr_proxy = StreamWriteProxy(stream=sys.stderr)
-        self._true_input = builtins.input
+        self._true_input_func = builtins.input
         self._as_atomic = threading.Lock()
         self._spinning_msg = None
 
@@ -87,7 +87,7 @@ class ConsoleSpinner:
 
         sys.stdout.write = self._stdout_proxy.true_stream_write
         sys.stderr.write = self._stderr_proxy.true_stream_write
-        builtins.input = self._true_input
+        builtins.input = self._true_input_func
 
     def update_spinner_msg(self, s, /, *, stream):
         with self._as_atomic:  # make sure that only a single thread at a time can update the spinning message

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -1,154 +1,118 @@
-import collections
+import functools
 import itertools
 import logging
-import queue
 import shutil
 import sys
 import threading
 import time
 
 
-class QueuedStreamHandler(logging.Handler):
-    """
-    A handler class which writes logging records, appropriately formatted,
-    to a queue.
-    """
+class StreamWriteProxy:
+    # TODO: DOC: Unable to copy sys.stdout
+    def __init__(self, *, stream):
+        self.stream = stream
+        self.true_stream_write = stream.write
 
-    def __init__(self, *, queue, stream=None):
-        """
-        Initialize the handler.
-        """
-        super().__init__()
-        self.queue = queue
-        if stream is None:
-            self.stream = sys.stderr
-        else:
-            self.stream = stream
+    def write(self, s, /):
+        self.true_stream_write(s)
 
-        self.StreamMsg = collections.namedtuple("StreamMsg", ["msg", "stream"])
-
-    def emit(self, record):
-        """
-        Emit a record.
-
-        If a formatter is specified, it is used to format the record.
-        The record is then written to the stream with a trailing newline.  If
-        exception information is present, it is formatted using
-        traceback.print_exception and appended to the stream.  If the stream
-        has an 'encoding' attribute, it is used to determine how to do the
-        output to the stream.
-        """
-
-        try:
-            msg = self.format(record)
-            self.queue.put(self.StreamMsg(msg=msg, stream=self.stream))
-        except Exception:
-            self.handleError(record)
-
-    # TODO: def flush()?
+    def __getattr__(self, name):
+        return getattr(self.stream, name)
 
 
-class ConsoleProgressHandler:
-    def __init__(self, queue):
-        """Construct the progress handler"""
-        self._queue = queue
+class ConsoleSpinner:
+    def __init__(self):
+        # TODO: DOC: Modify true sys.std* to allow for context change at any point in time
+        self._stdout_proxy = StreamWriteProxy(stream=sys.stdout)
+        self._stderr_proxy = StreamWriteProxy(stream=sys.stderr)
+        self._spinning_msg = None
+
+    def __enter__(self):
+        sys.stdout.write = functools.partial(
+            self.update_spinner_msg, stream=self._stdout_proxy
+        )
+        sys.stderr.write = functools.partial(
+            self.update_spinner_msg, stream=self._stderr_proxy
+        )
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._spinning_msg is not None:
+            self._spinning_msg.stop()
+
+        sys.stdout.write = self._stdout_proxy.true_stream_write
+        sys.stderr.write = self._stderr_proxy.true_stream_write
+
+    def update_spinner_msg(self, s, /, *, stream):
+        if self._spinning_msg is not None:
+            # Stop currently spinning message
+            self._spinning_msg.stop()
+
+        # Start spinning the new message
+        self._spinning_msg = MessageSpinner(msg=s, stream=stream)
+        self._spinning_msg.start()
+
+
+class MessageSpinner:
+    def __init__(self, *, msg, stream):
+        self._msg = msg
+        self._stream = stream
+
         self._spinner_cycle = itertools.cycle("⣾⣷⣯⣟⡿⢿⣻⣽")
-        self._spinner_thread = threading.Thread(target=self._spinner_run_sequence)
-        self._stop = threading.Event()
+        self._spinner_thread = threading.Thread(target=self._spin_msg)
+        self._stop_signal = threading.Event()
         self._sleep_interval = 0.1
         self._print_width = shutil.get_terminal_size()[0] - 2
+        self._running = False
 
         # \033[2K erases the old line to avoid the extra two
         # characters at the end of the line stemming from the shift
-        # of the line due to the spinner character and a whitespace
+        # of the line due to the leading spinner character and a whitespace
         self._clear_line_code = "\r\033[2K"
 
-    def __enter__(self):
-        self.start()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self._queue.join()
-        self.stop()
-
     def start(self):
-        """
-        Start the process of printing out the latest message.
-        It will run until the stop function is being called.
-        """
         self._spinner_thread.start()
+        self._running = True
 
-    def _spinner_run_sequence(self):
-        current_item = None
-        while not self._stop.is_set():
-            time.sleep(self._sleep_interval)
-            try:
-                if current_item is None:
-                    # Poll for first SteamMsg on queue
-                    current_item = self._queue.get_nowait()
-                else:
-                    # Check for new SteamMsg
-                    new_item = self._queue.get_nowait()
+    def stop(self):
+        if self._running:
+            self._stop_signal.set()
+            self._spinner_thread.join()
+            self._running = False
 
-                    # Print old StreamMsg if a new one is ready
-                    print(
-                        f"{self._clear_line_code}{current_item.msg}",
-                        file=current_item.stream,
-                        flush=True,
-                    )
-                    current_item = new_item
-
-                self._queue.task_done()
-
-            except queue.Empty:
-                if current_item is None:
-                    # 
-                    continue
-
+    def _spin_msg(self):
+        msg = self._msg.rstrip("\n")  # we control newlines ourselves
+        while not self._stop_signal.is_set():
             # Update spinner
             print(
                 f"{self._clear_line_code}{next(self._spinner_cycle)} "
-                f"{current_item.msg[:self._print_width]}",
-                end="",  # no newline to keep overwriting current line
-                file=current_item.stream,
-                flush=True,
+                f"{msg[:self._print_width]}",  # restrict output to terminal width
+                end="",  # keep overwriting current line
+                file=self._stream,
             )
+            time.sleep(self._sleep_interval)
 
-        # Print final StreamMsg without spinner (if any)
-        if current_item is not None:
-            print(
-                f"{self._clear_line_code}{current_item.msg}",
-                file=current_item.stream,
-                flush=True,
-            )
-
-    def stop(self):
-        """Stop the printing process"""
-        self._stop.set()
-        self._spinner_thread.join()
+        # Print message without spinner (incl. trailing newline)
+        print(f"{self._clear_line_code}{msg}", file=self._stream)
 
 
 class LogDispatcher:
     # TODO: Cleanup and document
-    def __init__(self, *, name, map_log_level_func, verbosity, console_log_msg_queue):
+    def __init__(self, *, name, map_log_level_func, verbosity):
         log_level = self._determine_log_level(verbosity=verbosity)
 
         # Setup cotainr log format
         if verbosity >= 2:
             console_log_formatter = logging.Formatter(
-                "%(asctime)s - %(name)s:%(levelname)s$ %(message)s"
+                "%(asctime)s - %(name)s:%(levelname)s %(message)s"
             )
         else:
             console_log_formatter = logging.Formatter(f"{name}:-: %(message)s")
 
         # Setup log handlers
-        console_stdout_handler = QueuedStreamHandler(
-            queue=console_log_msg_queue, stream=sys.stdout
-        )
+        console_stdout_handler = logging.StreamHandler(stream=sys.stdout)
         console_stdout_handler.setLevel(log_level)
         console_stdout_handler.setFormatter(console_log_formatter)
-        console_stderr_handler = QueuedStreamHandler(
-            queue=console_log_msg_queue, stream=sys.stderr
-        )
+        console_stderr_handler = logging.StreamHandler(stream=sys.stderr)
         console_stderr_handler.setLevel(log_level)
         console_stderr_handler.setFormatter(console_log_formatter)
 
@@ -163,6 +127,7 @@ class LogDispatcher:
 
     def log_to_stdout(self, msg):
         self.logger_stdout.log(level=self.map_log_level(msg), msg=msg.strip())
+        # TODO: consider stripping level in msg
 
     def log_to_stderr(self, msg):
         self.logger_stderr.log(level=self.map_log_level(msg), msg=msg.strip())

--- a/cotainr/util.py
+++ b/cotainr/util.py
@@ -132,7 +132,8 @@ def _print_and_capture_stream(*, stream_handle, print_dispatch):
     ----------
     stream_handle : io.TextIOWrapper
         The text stream to print and capture.
-    print_dispatch : ...
+    print_dispatch : Callable
+        The callable to use for printing.
     """
     captured_stream = []
     for line in stream_handle:

--- a/cotainr/util.py
+++ b/cotainr/util.py
@@ -58,7 +58,7 @@ def get_systems():
         return {}
 
 
-def stream_subprocess(*, args, log_dispatcher=None, **kwargs):
+def stream_subprocess(*, log_dispatcher=None, args, **kwargs):
     """
     Run a the command described by `args` while streaming stdout and stderr.
 

--- a/cotainr/util.py
+++ b/cotainr/util.py
@@ -63,8 +63,9 @@ def stream_subprocess(*, args, log_dispatcher=None, **kwargs):
     Run a the command described by `args` while streaming stdout and stderr.
 
     The command described by `args` is run in a subprocess with that
-    subprocess' stdout and stderr streamed to the main process. Extra `kwargs`
-    are passed to `Popen` when opening the subprocess.
+    subprocess' stdout and stderr streamed to the main process. Each line in
+    the subprocess' output is streamed separately to the main process. Extra
+    `kwargs` are passed to `Popen` when opening the subprocess.
 
     Parameters
     ----------

--- a/cotainr/util.py
+++ b/cotainr/util.py
@@ -58,7 +58,7 @@ def get_systems():
         return {}
 
 
-def stream_subprocess(*, log_dispatcher=None, args, **kwargs):
+def stream_subprocess(*, args, log_dispatcher=None, **kwargs):
     """
     Run a the command described by `args` while streaming stdout and stderr.
 
@@ -71,8 +71,10 @@ def stream_subprocess(*, log_dispatcher=None, args, **kwargs):
     args : list or str
         Program arguments. See the docstring for :class:`subprocess.Popen` for
         details.
-    TODO: Cleanup and document
-    TODO: Consider reworking to avoid API break
+    log_dispatcher : :class:`~cotainr.tracing.LogDispatcher`, optional
+        The log dispatcher which subprocess stdout/stderr messages are
+        forwarded to (the default is None which implies that subprocess
+        messages are forwarded directly to stdout/stderr).
 
     Returns
     -------
@@ -134,6 +136,11 @@ def _print_and_capture_stream(*, stream_handle, print_dispatch):
         The text stream to print and capture.
     print_dispatch : Callable
         The callable to use for printing.
+
+    Returns
+    -------
+    captured_stream : list of str
+        The lines captured from the stream.
     """
     captured_stream = []
     for line in stream_handle:

--- a/cotainr/util.py
+++ b/cotainr/util.py
@@ -132,7 +132,7 @@ def _print_and_capture_stream(*, stream_handle, print_dispatch):
 
     Parameters
     ----------
-    stream_handle : io.TextIOWrapper
+    stream_handle : :py:class:`io.TextIOWrapper`
         The text stream to print and capture.
     print_dispatch : Callable
         The callable to use for printing.

--- a/cotainr/util.py
+++ b/cotainr/util.py
@@ -95,7 +95,10 @@ def stream_subprocess(*, args, log_dispatcher=None, **kwargs):
         bufsize=1,
         **kwargs,
     ) as process:
-        with ThreadPoolExecutor(max_workers=2) as executor:
+        with ThreadPoolExecutor(
+            max_workers=2,
+            thread_name_prefix=f"cotainr_stream_subprocess_thread_for_{args}",
+        ) as executor:
             # (Attempt to) pass the process stdout and stderr to the terminal in real
             # time while also storing it for later inspection.
             stdout_future = executor.submit(

--- a/cotainr/util.py
+++ b/cotainr/util.py
@@ -140,31 +140,3 @@ def _print_and_capture_stream(*, stream_handle, print_dispatch):
         captured_stream.append(line)
 
     return captured_stream
-
-
-class LogDispatcher:
-    #TODO: Cleanup and document
-    def __init__(
-        self,
-        *,
-        name,
-        map_log_level_func,
-        log_level,
-        stdout_log_handlers,
-        stderr_log_handlers,
-    ):
-        self.logger_stdout = logging.getLogger(f"{name}.stdout")
-        for handler in stdout_log_handlers:
-            self.logger_stdout.addHandler(handler)
-        self.logger_stdout.setLevel(log_level)
-        self.logger_stderr = logging.getLogger(f"{name}.stderr")
-        for handler in stderr_log_handlers:
-            self.logger_stderr.addHandler(handler)
-        self.logger_stderr.setLevel(log_level)
-        self.map_log_level = map_log_level_func
-
-    def log_to_stdout(self, msg):
-        self.logger_stdout.log(level=self.map_log_level(msg), msg=msg.strip())
-
-    def log_to_stderr(self, msg):
-        self.logger_stderr.log(level=self.map_log_level(msg), msg=msg.strip())

--- a/cotainr/util.py
+++ b/cotainr/util.py
@@ -63,8 +63,8 @@ def stream_subprocess(*, log_dispatcher=None, args, **kwargs):
     Run a the command described by `args` while streaming stdout and stderr.
 
     The command described by `args` is run in a subprocess with that
-    subprocess' stdout and stderr streamed to the stdout. Extra `kwargs` are
-    passed to `Popen` when opening the subprocess.
+    subprocess' stdout and stderr streamed to the main process. Extra `kwargs`
+    are passed to `Popen` when opening the subprocess.
 
     Parameters
     ----------

--- a/doc/api_reference/index.rst
+++ b/doc/api_reference/index.rst
@@ -10,4 +10,5 @@ The full public cotainr API is listed below.
    cotainr.cli
    cotainr.container
    cotainr.pack
+   cotainr.tracing
    cotainr.util

--- a/doc/development/index.rst
+++ b/doc/development/index.rst
@@ -18,7 +18,7 @@ All contributions, including bug reports, bug fixes, documentation, and new feat
 
 Feedback & bug reports
 ~~~~~~~~~~~~~~~~~~~~~~
-If you would like to report a bug, request a new features, or provide feedback and/or ideas for improving `cotainr`, please create an issue on the `cotainr` issue tracker: https://github.com/DeiC-HPC/cotainr/issues. A guide for creating an issue on GitHub is available in the `GitHub issue docs <https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue>`_. Before creating a new issue, please check if somebody else has already opened a similar issue. If so, please contribute your thoughts and experiences to the discussion in that issues instead of opening a new one. If reporting a bug, please provide a `minimal reproducible example <https://stackoverflow.com/help/minimal-reproducible-example>`_ of the problem.
+If you would like to report a bug, request a new features, or provide feedback and/or ideas for improving `cotainr`, please create an issue on the `cotainr` issue tracker: https://github.com/DeiC-HPC/cotainr/issues. A guide for creating an issue on GitHub is available in the `GitHub issue docs <https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue>`_. Before creating a new issue, please check if somebody else has already opened a similar issue. If so, please contribute your thoughts and experiences to the discussion in that issue instead of opening a new one. If reporting a bug, please provide a `minimal reproducible example <https://stackoverflow.com/help/minimal-reproducible-example>`_ of the problem.
 
 Code & documentation contributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -35,5 +35,6 @@ If you would like to contribute changes to the `cotainr` codebase or documentati
     documentation
     technical_motivation
     cli_internals
+    tracing_logging
     releasing
     systems

--- a/doc/development/systems.rst
+++ b/doc/development/systems.rst
@@ -5,7 +5,7 @@ Predefining systems
 
 To make `cotainr` easier to use, you can predefine systems.
 This currently means specifying a base image for a part of your HPC system.
-This can be done make a json file called `systems.json` in the project root folder.
+This can be done by creating a `JSON <https://www.json.org/>_` file named `systems.json` in the project root folder.
 
 Why should I do this?
 ---------------------
@@ -16,8 +16,8 @@ If it is not trivial for the users to get MPI or GPU access working in container
 File format
 -----------
 
-The file format is relatively simple. For each system you give them a name and then add a base image for them.
-The base image path can be one of the support targets for `apptainer build <https://apptainer.org/docs/user/latest/build_a_container.html#overview>`_.
+The file format is relatively simple. For each you give it a name and then add a base image.
+The base image path can be one of the support targets for `apptainer/singularity build <https://apptainer.org/docs/user/latest/build_a_container.html#overview>`_.
 
 .. code-block:: json
 

--- a/doc/development/tracing_logging.rst
+++ b/doc/development/tracing_logging.rst
@@ -2,7 +2,7 @@
 
 Tracing & logging
 =================
-As `cotainr` is a tools that wraps other tools, e.g. Singularity and Conda, quite of a lot of text messages are passed around. In particular, we handle:
+As `cotainr` is a tools that wraps other tools, e.g. Singularity and Conda, quite a lot of text messages are passed around. In particular, we handle:
 
 - Printed information from `cotainr`.
 - Logging information from `cotainr`.
@@ -15,13 +15,13 @@ The `cotainr` tracing & logging setup handles all of this in a consistent way.
 
 Cotainr logging
 ---------------
-Logging in `cotainr` is handled using the `Python standard library logging module <https://docs.python.org/3/library/logging.html>`_. We use the standard convention of creating loggers on a per-module basis, i.e. all module in `cotainr` includes a :code:`logger = logging.getLogger(__name__)` line following any imports. Logging is then done by using the module logger, e.g. :code:`logger.info("Some logged message.")`.
+Logging in `cotainr` is handled using the `Python standard library logging module <https://docs.python.org/3/library/logging.html>`_. We use the standard convention of creating loggers on a per-module basis, i.e. all modules in `cotainr` include a :code:`logger = logging.getLogger(__name__)` line following any imports. Logging is then done using the module logger, e.g. :code:`logger.info("Some logged message.")`.
 
 The `cotainr` library does not define any `logging handlers <https://docs.python.org/3/howto/logging.html#handlers>`_. This is left for the user of the library. When using the :ref:`cotainr CLI <command_line_interface>`, though, a set of handlers is defined as outlined in the description of the `Cotainr CLI tracing`_.
 
 Cotainr CLI tracing
 -------------------
-When using the `cotainr CLI` quite a lot of messages from `cotainr` and subprocesses needs to filtered, annotated, routed, and displayed on the console and/or written to files to provide the most useful information to the use. This process of providing the most useful information to the to the user, we refer to as "tracing." Tracing in `cotainr` is done using three separate abstractions:
+When using the `cotainr CLI`, quite a lot of messages from `cotainr` and subprocesses needs to filtered, annotated, routed, and displayed on the console and/or written to files to provide the most useful information to the user. This process of providing the most useful information to the user, we refer to as "tracing." Tracing in `cotainr` is done using three separate abstractions:
 
 - `Forwarding of stdout/stdout from subprocesses`_
 - `Processing of log messages`_
@@ -29,9 +29,9 @@ When using the `cotainr CLI` quite a lot of messages from `cotainr` and subproce
 
 Forwarding of stdout/stdout from subprocesses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When external programs, e.g. Singularity or Conda, are called in separate subproceses, their output on `stdout`/`stderr` is captured and forwarded in real time to the main process. It may then either be directly piped to the main process `stdout`/`stderr` or further processed using the setup described in `Processing of log messages`_.
+When external programs, e.g. Singularity or Conda, are called in separate subproceses, their output on `stdout` / `stderr` is captured and forwarded in real time to the main process. It may then either be directly piped to the main process `stdout` / `stderr` or further processed using the setup described in `Processing of log messages`_.
 
-The real time forwarding of `stdout`/`stderr` is implemented by the :func:`cotainr.util.stream_subprocess` function which is used when running the subprocesses.
+The real time forwarding of `stdout` / `stderr` is implemented by the :func:`cotainr.util.stream_subprocess` function which is used when running the subprocesses.
 
 Processing of log messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -39,14 +39,14 @@ The `Python logging <https://docs.python.org/3/library/logging.html>`_ machinery
 
 This setup is primarily implemented by two classes :class:`cotainr.tracing.LogDispatcher` and :class:`cotainr.tracing.LogSettings`. Each subprocess is linked to a :class:`~cotainr.tracing.LogDispatcher` instance which sets up the logging machinery based on the supplied :class:`~cotainr.tracing.LogSettings`, any `filters <https://docs.python.org/3/library/logging.html#filter-objects>`_, and a `map_log_level_func` function, to:
 
-- Set the correct log level based on verbosity (as described in `Cotainr tracing log levels`_).
-- Specify the logging message format based on verbosity.
-- Setup `StreamHandlers <https://docs.python.org/3/library/logging.handlers.html#streamhandler>`_ for `stdout`/`stderr`.
-- Setup `FileHandlers <https://docs.python.org/3/library/logging.handlers.html#filehandler>`_ for `stdout`/`stderr`, if requested.
+- Determine the correct log level for loggers and handlers based on `verbosity` (as described in `Cotainr tracing log levels`_).
+- Specify the logging message format based on `verbosity`.
+- Setup `StreamHandlers <https://docs.python.org/3/library/logging.handlers.html#streamhandler>`_ for `stdout` / `stderr`.
+- Setup `FileHandlers <https://docs.python.org/3/library/logging.handlers.html#filehandler>`_ for `stdout` / `stderr`, if requested.
 - Apply any filters to modify and/or remove log messages.
 - Add colored console output based on log level, as implemented in :class:`cotainr.tracing.ColoredOutputFormatter`, if requested.
 
-The :class:`~cotainr.tracing.LogDispatcher` then defines methods :meth:`~cotainr.tracing.LogDispatcher.log_to_stdout` and :meth:`~cotainr.tracing.LogDispatcher.log_to_stdout` which may be used to log to `stdout`/`stderr`, respectively, at a log level determined by the provided `map_log_level_func` function. 
+The :class:`~cotainr.tracing.LogDispatcher` then defines methods :meth:`~cotainr.tracing.LogDispatcher.log_to_stdout` and :meth:`~cotainr.tracing.LogDispatcher.log_to_stderr` which may be used with subprocesses to log to `stdout` / `stderr`, respectively, at a message log level determined by the provided `map_log_level_func` function. 
 
 In order to take advantage of this machinery, CLI subcommands must:
 
@@ -57,24 +57,23 @@ In order to take advantage of this machinery, CLI subcommands must:
 
 An example of a subcommand implementing this is :class:`cotainr.cli.Build`.
 
-Futhermore, `cotainr` functionality that spawn subprocesses, e.g. :class:`cotainr.container.SingularitySandbox` or :class:`cotainr.pack.CondaInstall` must implement a `map_log_level_func` function, that (attempts to) infers the correct logging level from a given message, and instantiate their own :class:`~cotainr.tracing.LogDispatcher`, which should be passed to :func:`cotainr.util.stream_subprocess` when spawning subprocesses.
+Futhermore, `cotainr` functionality that spawn subprocesses, e.g. :class:`cotainr.container.SingularitySandbox` or :class:`cotainr.pack.CondaInstall` must:
 
-Similarly to the setup done by :class:`~cotainr.tracing.LogDispatcher` for subprocess, the :class:`cotainr.cli.CotainrCLI` sets up the `cotainr` root logger for the main process based on the subcommand :class:`~cotainr.tracing.LogSettings`. This is implemented in the :meth:`~cotainr.cli.CotainrCLI._setup_cotainr_cli_logging` method.
+- Implement a `map_log_level_func` function, that (attempts to) infers the correct logging level for a given message.
+- Instantiate their own :class:`~cotainr.tracing.LogDispatcher`, which should be passed to :func:`cotainr.util.stream_subprocess` when spawning subprocesses.
 
-Adding a console spinner
-~~~~~~~~~~~~~~~~~~~~~~~~
-A spinner may be added to the console `stdout`/`stderr` output for some code by running the code in a :class:`cotainr.tracing.ConsoleSpinner` context.
+An example of this is given in :class:`cotainr.pack.CondaInstall` which implements the static method :meth:`cotainr.pack.CondaInstall._map_log_level` and instantiates a :class:`~cotainr.tracing.LogDispatcher` in its constructor.
 
-The spinner is implemented in the :class:`cotainr.tracing.MessageSpinner` class which manages a separate thread updating the spinner for each individual message. Within the :class:`~cotainr.tracing.ConsoleSpinner` context, the spinning message is updated by monkey patching :py:meth:`sys.stdout.write`/:py:meth:`std.stderr.write` with :class:`cotainr.tracing.StreamWriteProxy` wrappers that make sure to update the spinning message whenever something is written to :py:data:`sys.stdout`/:py:data:`sys.stderr`.
+Similarly to the setup done by :class:`~cotainr.tracing.LogDispatcher` for subprocesses, the :class:`cotainr.cli.CotainrCLI` sets up the `cotainr` root logger for the main process based on the subcommand :class:`~cotainr.tracing.LogSettings`. This is implemented in the :meth:`cotainr.cli.CotainrCLI._setup_cotainr_cli_logging` method.
 
 Cotainr tracing log levels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-Within `cotainr`, we map the subcommand `--verbose`/`--quiet` flags to a `verbosity` level, one of the `standard Python logging levels <https://docs.python.org/3/library/logging.html#logging-levels>`_ (independently for `cotainr` and :class:`~cotainr.tracing.LogDispatcher`'s), and `--verbose`/`--quiet` levels for subprocesses, e.g. Singularity or Conda. Specifically the mapping is as shown in the below table:
+Within `cotainr`, we map the subcommand `--verbose` / `--quiet` flags to a `verbosity` level, one of the `standard Python logging levels <https://docs.python.org/3/library/logging.html#logging-levels>`_ (independently for `cotainr` and :class:`~cotainr.tracing.LogDispatcher`s), and `--verbose` / `--quiet` levels for subprocesses, e.g. Singularity or Conda. Specifically the mapping is as shown in the below table:
 
 ===================  =====================  ====================  ===========================  =======================  =================
   cotainr verbose      cotainr verbosity     cotainr log level      LogDispatcher log level      Singularity verbose      Conda verbose
 ===================  =====================  ====================  ===========================  =======================  =================
--q                   -1                     CRITICAL              CRITICAL                     -q                       -q
+-q                   -1                     CRITICAL              CRITICAL                     -s                       -q
 <None>               0                      INFO                  WARNING                      -q                       -q
 -v                   1                      INFO                  INFO                         <None>                   <None>
 -vv                  2                      DEBUG                 INFO                         <None>                   -v
@@ -82,5 +81,17 @@ Within `cotainr`, we map the subcommand `--verbose`/`--quiet` flags to a `verbos
 -vvvv                4                      DEBUG                 DEBUG                        -v                       -vvv
 ===================  =====================  ====================  ===========================  =======================  =================
 
-TODO: SOMETHING ABOUT THE IMPLEMENTATION OF THIS MAPPING, E.G. `map_log_level_func` AND CLI LOGGING SETUP / LogDispatcher 
-TODO: ADD LINKS FOR CONDA/SINGULARITY REFERENCES
+The subcommand `--verbose` / `--quiet` flags are mapped to a `verbosity` level as part of the parsing of the CLI arguments, e.g. as in :class:`cotainr.CLI.build.add_arguments`. Based on the `verbosity` level,
+
+- the `cotainr` log level (as used for filtering messages in loggers and handlers) is set in the :meth:`cotainr.cli.CotainrCLI._setup_cotainr_cli_logging` method.
+- the :class:`~cotainr.tracing.LogDispatcher` log level (as used for filtering messages in loggers and handlers) is set as part of its construction, i.e. in :meth:`cotainr.tracing.LogDispatcher._determine_log_level` method.
+- the Singularity `--verbose` / `--quiet` flags are injected into Singularity subprocess commands using the :meth:`cotainr.container.SingularitySandbox._add_verbosity_arg` method.
+- the Conda `-v` / `-q` flags are appended to Conda subprocess commands using the :meth:`cotainr.pack.CondaInstall._conda_verbosity_arg` method.
+
+Note the this means that logged messages may be filtered by both the subprocess command (e.g. singularity), the logger used to log the message, and the handler used to emit the message to the console and/or a file.
+
+Adding a console spinner
+~~~~~~~~~~~~~~~~~~~~~~~~
+For a given block of code, a spinner may be added to any console output to `stdout` / `stderr` from that code by running it in a :class:`cotainr.tracing.ConsoleSpinner` context.
+
+The spinner is implemented in the :class:`cotainr.tracing.MessageSpinner` class which manages a separate thread updating the spinner for each individual message. Within the :class:`~cotainr.tracing.ConsoleSpinner` context, the spinning message is updated by monkey patching :py:meth:`sys.stdout.write`/:py:meth:`std.stderr.write` with :class:`cotainr.tracing.StreamWriteProxy` wrappers that make sure to update the spinning message whenever something is written to :py:data:`sys.stdout`/:py:data:`sys.stderr`.

--- a/doc/development/tracing_logging.rst
+++ b/doc/development/tracing_logging.rst
@@ -1,0 +1,86 @@
+.. _tracing_logging:
+
+Tracing & logging
+=================
+As `cotainr` is a tools that wraps other tools, e.g. Singularity and Conda, quite of a lot of text messages are passed around. In particular, we handle:
+
+- Printed information from `cotainr`.
+- Logging information from `cotainr`.
+- Messages sent to `stdout` by subprocess, e.g. Singularity or Conda.
+- Messages sent to `stderr` by subprocess, e.g. Singularity or Conda.
+
+All of these have to be filtered, annotated, routed, and displayed on the console and/or written to files.
+
+The `cotainr` tracing & logging setup handles all of this in a consistent way.
+
+Cotainr logging
+---------------
+Logging in `cotainr` is handled using the `Python standard library logging module <https://docs.python.org/3/library/logging.html>`_. We use the standard convention of creating loggers on a per-module basis, i.e. all module in `cotainr` includes a :code:`logger = logging.getLogger(__name__)` line following any imports. Logging is then done by using the module logger, e.g. :code:`logger.info("Some logged message.")`.
+
+The `cotainr` library does not define any `logging handlers <https://docs.python.org/3/howto/logging.html#handlers>`_. This is left for the user of the library. When using the :ref:`cotainr CLI <command_line_interface>`, though, a set of handlers is defined as outlined in the description of the `Cotainr CLI tracing`_.
+
+Cotainr CLI tracing
+-------------------
+When using the `cotainr CLI` quite a lot of messages from `cotainr` and subprocesses needs to filtered, annotated, routed, and displayed on the console and/or written to files to provide the most useful information to the use. This process of providing the most useful information to the to the user, we refer to as "tracing." Tracing in `cotainr` is done using three separate abstractions:
+
+- `Forwarding of stdout/stdout from subprocesses`_
+- `Processing of log messages`_
+- `Adding a console spinner`_
+
+Forwarding of stdout/stdout from subprocesses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When external programs, e.g. Singularity or Conda, are called in separate subproceses, their output on `stdout`/`stderr` is captured and forwarded in real time to the main process. It may then either be directly piped to the main process `stdout`/`stderr` or further processed using the setup described in `Processing of log messages`_.
+
+The real time forwarding of `stdout`/`stderr` is implemented by the :func:`cotainr.util.stream_subprocess` function which is used when running the subprocesses.
+
+Processing of log messages
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+The `Python logging <https://docs.python.org/3/library/logging.html>`_ machinery is used for advanced processing of all text messages to be displayed on the console and, optionally, written to a file.
+
+This setup is primarily implemented by two classes :class:`cotainr.tracing.LogDispatcher` and :class:`cotainr.tracing.LogSettings`. Each subprocess is linked to a :class:`~cotainr.tracing.LogDispatcher` instance which sets up the logging machinery based on the supplied :class:`~cotainr.tracing.LogSettings`, any `filters <https://docs.python.org/3/library/logging.html#filter-objects>`_, and a `map_log_level_func` function, to:
+
+- Set the correct log level based on verbosity (as described in `Cotainr tracing log levels`_).
+- Specify the logging message format based on verbosity.
+- Setup `StreamHandlers <https://docs.python.org/3/library/logging.handlers.html#streamhandler>`_ for `stdout`/`stderr`.
+- Setup `FileHandlers <https://docs.python.org/3/library/logging.handlers.html#filehandler>`_ for `stdout`/`stderr`, if requested.
+- Apply any filters to modify and/or remove log messages.
+- Add colored console output based on log level, as implemented in :class:`cotainr.tracing.ColoredOutputFormatter`, if requested.
+
+The :class:`~cotainr.tracing.LogDispatcher` then defines methods :meth:`~cotainr.tracing.LogDispatcher.log_to_stdout` and :meth:`~cotainr.tracing.LogDispatcher.log_to_stdout` which may be used to log to `stdout`/`stderr`, respectively, at a log level determined by the provided `map_log_level_func` function. 
+
+In order to take advantage of this machinery, CLI subcommands must:
+
+- Implement the `--verbose` and `--quiet` arguments and map them to the `verbosity` level as described in `Cotainr tracing log levels`_.
+- Implement the `--log-to-file` argument and map it to a `log_file_path`.
+- Implement the `--no-color` argument.
+- Instantiate a :class:`~cotainr.tracing.LogSettings` object and pass it onto any cotainr functionality that may spawn subprocesses.
+
+An example of a subcommand implementing this is :class:`cotainr.cli.Build`.
+
+Futhermore, `cotainr` functionality that spawn subprocesses, e.g. :class:`cotainr.container.SingularitySandbox` or :class:`cotainr.pack.CondaInstall` must implement a `map_log_level_func` function, that (attempts to) infers the correct logging level from a given message, and instantiate their own :class:`~cotainr.tracing.LogDispatcher`, which should be passed to :func:`cotainr.util.stream_subprocess` when spawning subprocesses.
+
+Similarly to the setup done by :class:`~cotainr.tracing.LogDispatcher` for subprocess, the :class:`cotainr.cli.CotainrCLI` sets up the `cotainr` root logger for the main process based on the subcommand :class:`~cotainr.tracing.LogSettings`. This is implemented in the :meth:`~cotainr.cli.CotainrCLI._setup_cotainr_cli_logging` method.
+
+Adding a console spinner
+~~~~~~~~~~~~~~~~~~~~~~~~
+A spinner may be added to the console `stdout`/`stderr` output for some code by running the code in a :class:`cotainr.tracing.ConsoleSpinner` context.
+
+The spinner is implemented in the :class:`cotainr.tracing.MessageSpinner` class which manages a separate thread updating the spinner for each individual message. Within the :class:`~cotainr.tracing.ConsoleSpinner` context, the spinning message is updated by monkey patching :py:meth:`sys.stdout.write`/:py:meth:`std.stderr.write` with :class:`cotainr.tracing.StreamWriteProxy` wrappers that make sure to update the spinning message whenever something is written to :py:data:`sys.stdout`/:py:data:`sys.stderr`.
+
+Cotainr tracing log levels
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Within `cotainr`, we map the subcommand `--verbose`/`--quiet` flags to a `verbosity` level, one of the `standard Python logging levels <https://docs.python.org/3/library/logging.html#logging-levels>`_ (independently for `cotainr` and :class:`~cotainr.tracing.LogDispatcher`'s), and `--verbose`/`--quiet` levels for subprocesses, e.g. Singularity or Conda. Specifically the mapping is as shown in the below table:
+
+===================  =====================  ====================  ===========================  =======================  =================
+  cotainr verbose      cotainr verbosity     cotainr log level      LogDispatcher log level      Singularity verbose      Conda verbose
+===================  =====================  ====================  ===========================  =======================  =================
+-q                   -1                     CRITICAL              CRITICAL                     -q                       -q
+<None>               0                      INFO                  WARNING                      -q                       -q
+-v                   1                      INFO                  INFO                         <None>                   <None>
+-vv                  2                      DEBUG                 INFO                         <None>                   -v
+-vvv                 3                      DEBUG                 DEBUG                        -v                       -vv
+-vvvv                4                      DEBUG                 DEBUG                        -v                       -vvv
+===================  =====================  ====================  ===========================  =======================  =================
+
+TODO: SOMETHING ABOUT THE IMPLEMENTATION OF THIS MAPPING, E.G. `map_log_level_func` AND CLI LOGGING SETUP / LogDispatcher 
+TODO: ADD LINKS FOR CONDA/SINGULARITY REFERENCES


### PR DESCRIPTION
This is a major rework of how we handle outputting information to the console. It consist of:

- Cotainr build CLI options `--verbose`/`--quiet` to adjust the verbosity of the output to the console.
- Cotainr build CLi option `--log-to-file` to also save the stdout/stderr messages to files in addition to showing them on the console.
- Colored console output (colored by severity of message) by default with cotainr build CLI option `--no-color` to disable colored output.
- A Python logging based setup for handling all messages being passed within cotainr, handled at the standard Python log levels: DEBUG, INFO, WARNING, ERROR, CRITICAL.
- Passing of verbosity levels to Singularity and Conda.
- Filtering of messages from Conda to remove partial progress bars and various ANSI escape codes that mess up the console output.
- Basic Cotainr build CLI progress messages.
- A console spinner which we prepend to the output message from the Cotainr build CLI while we are waiting for the next output message.
- A development documentation page detailing how all of this works.
- A few minor clean-ups.

Once this PR is merged, we should close #32 as this PR supersedes #32.