### PR TITLE
Add support for pip/virtualenv environments

### DIFF
--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -30,6 +30,7 @@ from abc import ABC, abstractmethod
 import argparse
 from datetime import datetime
 import logging
+import os
 from pathlib import Path
 import platform
 import re
@@ -40,7 +41,7 @@ import time
 
 from . import __version__ as _cotainr_version
 from . import _minimum_dependency_version as _min_dep_ver
-from . import container, pack, tracing, util
+from . import container, pack, pip, tracing, util
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +84,8 @@ class Build(CotainrSubcommand):
         Path to a Conda environment.yml file to install and activate in the
         container. When installing a Conda environment, you must accept the
         Miniforge license terms, as specified during the build process.
+    requirements_txt : :class:`os.PathLike`, optional
+        Path to a requirements.txt file to install in the container.
     system : str
         Which system/partition you will be running the container on. This sets
         base image and other parameters for a simpler container creation.
@@ -107,6 +110,7 @@ class Build(CotainrSubcommand):
         image_path,
         base_image=None,
         conda_env=None,
+        requirements_txt=None,
         system=None,
         accept_licenses=False,
         verbosity=0,
@@ -144,6 +148,7 @@ class Build(CotainrSubcommand):
                 self.base_image = self.system["base-image"]
             else:
                 raise KeyError("System does not exist")
+
         if conda_env is not None:
             self.conda_env = Path(conda_env).resolve()
             if not self.conda_env.exists():
@@ -152,6 +157,15 @@ class Build(CotainrSubcommand):
                 )
         else:
             self.conda_env = None
+
+        if requirements_txt is not None:
+            self.requirements_txt = Path(requirements_txt).resolve()
+            if not self.requirements_txt.is_file():
+                raise FileNotFoundError(
+                    f"The provided requirements.txt file '{self.requirements_txt}' is not a file."
+                )
+        else:
+            self.requirements_txt = None
 
     @classmethod
     def add_arguments(cls, *, parser):
@@ -170,9 +184,17 @@ class Build(CotainrSubcommand):
             "--system",
             help=_extract_help_from_docstring(arg="system", docstring=cls.__doc__),
         )
-        parser.add_argument(
+        sources = parser.add_mutually_exclusive_group()
+        sources.add_argument(
             "--conda-env",
             help=_extract_help_from_docstring(arg="conda_env", docstring=cls.__doc__),
+            type=Path,
+        )
+        sources.add_argument(
+            "--requirements-txt",
+            help=_extract_help_from_docstring(
+                arg="requirements_txt", docstring=cls.__doc__
+            ),
             type=Path,
         )
         parser.add_argument(
@@ -245,6 +267,26 @@ class Build(CotainrSubcommand):
                     conda_install.cleanup_unused_files()
                     logger.info(
                         "Finished installing conda environment: %s", self.conda_env
+                    )
+                if self.requirements_txt is not None:
+                    logger.info(
+                        "Creating virtualenv with requirements: %s",
+                        self.requirements_txt,
+                    )
+                    requirements_txt_file = (
+                        sandbox.sandbox_dir / "cotainr_requirements.txt"
+                    )
+                    shutil.copyfile(self.requirements_txt, requirements_txt_file)
+                    pip_install = pip.PipInstall(
+                        sandbox=sandbox,
+                        log_settings=self.log_settings,
+                        use_uv=bool(os.environ.get("COTAINR_USE_UV")),
+                    )
+                    pip_install.configure(
+                        requirements_files=[requirements_txt_file], add_to_env=True
+                    )
+                    logger.info(
+                        "Finished installing virtualenv in %s", pip_install.prefix
                     )
 
                 logger.info("Adding metadata to container")

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -212,8 +212,9 @@ class SingularitySandbox:
 
         Parameters
         ----------
-        cmd : str
+        cmd : str | list
             The command to run in the container sandbox.
+            If a string, subjected to `shlex.split()`; if a list, passed through as-is.
         custom_log_dispatcher : :class:`~cotainr.tracing.LogDispatcher`, optional
             The custom log dispatcher to use when running the command (the
             default is None which implies that the `SingularitySandbox` log
@@ -247,6 +248,10 @@ class SingularitySandbox:
         self._assert_within_sandbox_context()
 
         try:
+            if isinstance(cmd, list):
+                args = [str(arg) for arg in cmd]
+            else:
+                args = shlex.split(cmd)
             process = self._subprocess_runner(
                 custom_log_dispatcher=custom_log_dispatcher,
                 args=self._add_verbosity_arg(
@@ -258,7 +263,7 @@ class SingularitySandbox:
                         "--no-home",
                         "--no-umask",
                         self.sandbox_dir,
-                        *shlex.split(cmd),
+                        *args,
                     ]
                 ),
             )

--- a/cotainr/pack.py
+++ b/cotainr/pack.py
@@ -13,6 +13,8 @@ CondaInstall
     A Conda installation in a container sandbox.
 """
 
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 import random
@@ -23,12 +25,134 @@ import time
 import urllib.error
 import urllib.request
 
-from . import tracing, util
+from . import container, tracing, util
 
 logger = logging.getLogger(__name__)
 
 
-class CondaInstall:
+class PackBase:
+    """Base class for packing software into a container sandbox."""
+
+    def __init__(
+        self,
+        *,
+        sandbox: container.SingularitySandbox,
+        log_settings: tracing.LogSettings | None = None,
+    ):
+        """
+        Initialize the PackBase class.
+
+        Parameters
+        ----------
+        sandbox : :class:`~cotainr.container.SingularitySandbox`
+            The sandbox in which things are installed.
+
+        log_settings : :class:`~cotainr.tracing.LogSettings`, optional
+            The data used to setup the logging machinery (the default is None which
+            implies that the logging machinery is not used).
+        """
+        self.sandbox = sandbox
+        if log_settings is not None:
+            self._verbosity = log_settings.verbosity
+            self.log_dispatcher = tracing.LogDispatcher(
+                name=self.__class__.__name__,
+                filters=self._create_logging_filters(),
+                map_log_level_func=self._map_log_level,
+                log_settings=log_settings,
+            )
+        else:
+            self._verbosity = 0
+            self.log_dispatcher = None
+
+    def _display_message(self, *, msg, log_level=None):
+        """
+        Display a message to the user.
+
+        Displays the message using the `log_dispatcher` if `log_level` is not
+        `None` and a `log_dispatcher` is defined for the `CondaInstall`.
+        Otherwise prints the message on stdout. When the `log_dispatcher` is
+        used, messages with `log_levels` of WARNING or above are sent to stderr
+        whereas massages with with `log_level` below WARNING are sent to
+        stdout.
+
+        Parameters
+        ----------
+        msg : str
+            The message to display to the user.
+        log_level : int, optional
+            The logging level to use for the message, e.g. `logging.INFO` or
+            `logging.WARNING`.
+        """
+        if self.log_dispatcher is None or log_level is None:
+            print(msg)
+        else:
+            if log_level >= logging.WARNING:
+                self.log_dispatcher.logger_stderr.log(level=log_level, msg=msg)
+            else:
+                self.log_dispatcher.logger_stdout.log(level=log_level, msg=msg)
+
+    def _run_command_in_sandbox(self, *, cmd):
+        """
+        Wrap the sandbox command runner to use class specific log_dispatcher.
+
+        Wraps calls to `self.sandbox.run_command_in_container` to use
+        self.log_dispatcher for log handling instead of the sandbox's log
+        dispatcher.
+
+        Parameters
+        ----------
+        cmd : str
+            The command to run in the container sandbox.
+
+        Returns
+        -------
+        process : :class:`subprocess.CompletedProcess`
+            Information about the process that ran in the container sandbox.
+        """
+        return self.sandbox.run_command_in_container(
+            cmd=cmd, custom_log_dispatcher=self.log_dispatcher
+        )
+
+    def _create_logging_filters(self):
+        """Return logging filters for this class."""
+        return []
+
+    @staticmethod
+    def _map_log_level(msg):
+        """
+        Attempt to infer log level for a message.
+
+        Parameters
+        ----------
+        msg : str
+            The message to infer log level for.
+
+        Returns
+        -------
+        log_level : int
+            One of the standard log levels (DEBUG, INFO, WARNING, ERROR, or
+            CRITICAL).
+        """
+        if (
+            msg.startswith("DEBUG")
+            or msg.startswith("VERBOSE")
+            or msg.startswith("TRACE")
+        ):
+            return logging.DEBUG
+        elif msg.startswith("INFO"):
+            return logging.INFO
+        elif msg.startswith("WARNING"):
+            return logging.WARNING
+        elif msg.startswith("ERROR"):
+            return logging.ERROR
+        elif msg.startswith("CRITICAL"):
+            return logging.CRITICAL
+        else:
+            # If no prefix on message, assume its INFO level
+            return logging.INFO
+
+
+class CondaInstall(PackBase):
     """
     A Conda installation in a container sandbox.
 
@@ -81,20 +205,10 @@ class CondaInstall:
         log_settings=None,
     ):
         """Bootstrap a conda installation."""
+        super().__init__(sandbox=sandbox, log_settings=log_settings)
         self.sandbox = sandbox
         self.prefix = prefix
         self.license_accepted = license_accepted
-        if log_settings is not None:
-            self._verbosity = log_settings.verbosity
-            self.log_dispatcher = tracing.LogDispatcher(
-                name=__class__.__name__,
-                map_log_level_func=self._map_log_level,
-                filters=self._logging_filters,
-                log_settings=log_settings,
-            )
-        else:
-            self._verbosity = 0
-            self.log_dispatcher = None
 
         # Download Miniforge installer
         conda_installer_path = (
@@ -190,33 +304,6 @@ class CondaInstall:
                 "We risk destroying the Conda install in "
                 f"{source_check_process.stdout.strip()}. Aborting!"
             )
-
-    def _display_message(self, *, msg, log_level=None):
-        """
-        Display a message to the user.
-
-        Displays the message using the `log_dispatcher` if `log_level` is not
-        `None` and a `log_dispatcher` is defined for the `CondaInstall`.
-        Otherwise prints the message on stdout. When the `log_dispatcher` is
-        used, messages with `log_levels` of WARNING or above are sent to stderr
-        whereas massages with with `log_level` below WARNING are sent to
-        stdout.
-
-        Parameters
-        ----------
-        msg : str
-            The message to display to the user.
-        log_level : int, optional
-            The logging level to use for the message, e.g. `logging.INFO` or
-            `logging.WARNING`.
-        """
-        if self.log_dispatcher is None or log_level is None:
-            print(msg)
-        else:
-            if log_level >= logging.WARNING:
-                self.log_dispatcher.logger_stderr.log(level=log_level, msg=msg)
-            else:
-                self.log_dispatcher.logger_stdout.log(level=log_level, msg=msg)
 
     def _display_miniforge_license_for_acceptance(self, *, installer_path):
         """
@@ -363,28 +450,6 @@ class CondaInstall:
         else:
             raise url_error
 
-    def _run_command_in_sandbox(self, *, cmd):
-        """
-        Wrap the sandbox command runner to use class specific log_dispatcher.
-
-        Wraps calls to `self.sandbox.run_command_in_container` to use
-        self.log_dispatcher for log handling instead of the sandbox's log
-        dispatcher.
-
-        Parameters
-        ----------
-        cmd : str
-            The command to run in the container sandbox.
-
-        Returns
-        -------
-        process : :class:`subprocess.CompletedProcess`
-            Information about the process that ran in the container sandbox.
-        """
-        return self.sandbox.run_command_in_container(
-            cmd=cmd, custom_log_dispatcher=self.log_dispatcher
-        )
-
     @property
     def _conda_verbosity_arg(self):
         """
@@ -414,8 +479,7 @@ class CondaInstall:
         else:
             return ""
 
-    @property
-    def _logging_filters(self):
+    def _create_logging_filters(self):
         """
         Create logging filters for messages from conda commands.
 
@@ -470,37 +534,3 @@ class CondaInstall:
         ]
 
         return logging_filters
-
-    @staticmethod
-    def _map_log_level(msg):
-        """
-        Attempt to infer log level for a message.
-
-        Parameters
-        ----------
-        msg : str
-            The message to infer log level for.
-
-        Returns
-        -------
-        log_level : int
-            One of the standard log levels (DEBUG, INFO, WARNING, ERROR, or
-            CRITICAL).
-        """
-        if (
-            msg.startswith("DEBUG")
-            or msg.startswith("VERBOSE")
-            or msg.startswith("TRACE")
-        ):
-            return logging.DEBUG
-        elif msg.startswith("INFO"):
-            return logging.INFO
-        elif msg.startswith("WARNING"):
-            return logging.WARNING
-        elif msg.startswith("ERROR"):
-            return logging.ERROR
-        elif msg.startswith("CRITICAL"):
-            return logging.CRITICAL
-        else:
-            # If no prefix on message, assume its INFO level
-            return logging.INFO

--- a/cotainr/pack.py
+++ b/cotainr/pack.py
@@ -101,7 +101,7 @@ class PackBase:
 
         Parameters
         ----------
-        cmd : str
+        cmd : str or list
             The command to run in the container sandbox.
 
         Returns

--- a/cotainr/pip.py
+++ b/cotainr/pip.py
@@ -1,0 +1,139 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Copyright Aarni Koskela
+
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+This module implements packing of software into the container.
+
+Classes
+-------
+PipInstall
+    A virtualenv + pip installation in a container sandbox.
+"""
+
+from __future__ import annotations
+
+import logging
+import os.path
+import pathlib
+import shlex
+
+from . import container, pack, tracing
+
+logger = logging.getLogger(__name__)
+
+
+PIP_INSTALL_ARGS = (
+    "--no-cache-dir",
+    "--disable-pip-version-check",
+    "--no-warn-script-location",
+)
+
+
+class PipInstall(pack.PackBase):
+    """A virtualenv + pip installation in a container sandbox."""
+
+    def __init__(
+        self,
+        *,
+        sandbox: container.SingularitySandbox,
+        prefix: str = "/opt/venv",
+        base_python: str = "python3",
+        use_uv: bool = False,
+        log_settings: tracing.LogSettings | None = None,
+    ):
+        """Bootstrap a virtualenv with requirements file(s)."""
+        super().__init__(sandbox=sandbox, log_settings=log_settings)
+        self.prefix = prefix
+        self.base_python = base_python
+        self.use_uv = use_uv
+
+        if self.use_uv:
+            self._run_command_in_sandbox(
+                cmd=[self.base_python, "-m", "pip", "install", *PIP_INSTALL_ARGS, "uv"],
+            )
+
+        if self.use_uv:
+            self._run_command_in_sandbox(
+                cmd=[
+                    self.base_python,
+                    "-m",
+                    "uv",
+                    "venv",
+                    self.prefix,
+                    "-p",
+                    self.base_python,
+                    "--seed",  # Although we'll be using `uv`, some other software may expect `pip` to be present
+                ],
+            )
+        else:
+            self._run_command_in_sandbox(
+                cmd=[self.base_python, "-m", "venv", self.prefix],
+            )
+
+        self.venv_python = os.path.join(self.prefix, "bin", "python")
+
+    def configure(  # noqa: D102 (TODO)
+        self,
+        *,
+        requirements_files: list[str | pathlib.Path],
+        add_to_env: bool,
+    ) -> None:
+        for file in requirements_files:
+            logger.info("Installing requirements from %s", file)
+            if self.use_uv:
+                self._run_command_in_sandbox(
+                    cmd=[
+                        self.base_python,
+                        "-m",
+                        "uv",
+                        "pip",
+                        "install",
+                        "--python",
+                        self.venv_python,
+                        "--no-cache",
+                        "--link-mode=copy",  # hard-linking/cloning won't work anyway
+                        "-r",
+                        str(file),
+                    ],
+                )
+            else:
+                self._run_command_in_sandbox(
+                    cmd=[
+                        self.venv_python,
+                        "-m",
+                        "pip",
+                        "install",
+                        *PIP_INSTALL_ARGS,
+                        "-r",
+                        str(file),
+                    ],
+                )
+
+        self.cleanup()  # We have to do this before adding the activate script to env, otherwise `base_python` is gone
+
+        if add_to_env:
+            logger.info(
+                "Adding virtualenv %s activation script to environment",
+                self.prefix,
+            )
+            activate_script = os.path.join(self.prefix, "bin/activate")
+            self.sandbox.add_to_env(shell_script=f"source {activate_script}")
+
+    def cleanup(self) -> None:  # noqa: D102 (TODO)
+        logger.info("Cleaning up Python installer caches")
+        self._run_command_in_sandbox(
+            cmd=[
+                "sh",
+                "-c",
+                f'rm -rf "$({shlex.quote(self.base_python)} -m pip cache dir)"',
+            ],
+        )
+        if self.use_uv:
+            self._run_command_in_sandbox(
+                cmd=[self.base_python, "-m", "uv", "-q", "cache", "clean"],
+            )

--- a/cotainr/tests/cli/test_build.py
+++ b/cotainr/tests/cli/test_build.py
@@ -466,44 +466,49 @@ class TestHelpMessage:
         with pytest.raises(SystemExit):
             CotainrCLI(args=["build", "--help"])
         stdout = capsys.readouterr().out
-        # whitespaces in the formatting often leads to failed tests.
-        # especially true when doing this test for Python =< 3.12 and >=3.13 due to differences in whitespace trimming.
-        # thus remove all \\n \\r \\t \\f and spaces.
-        stdout = " ".join(stdout.split())
-        target = (
-            # Capsys apparently assumes an 80 char terminal (?) - thus extra '\n'
-            "usage: cotainr build [-h] (--base-image BASE_IMAGE | --system SYSTEM)\n"
-            "                     [--conda-env CONDA_ENV] [--accept-licenses]\n"
-            "                     [--verbose | --quiet] [--log-to-file] [--no-color]\n"
-            "                     image_path\n\n"
-            "Build a container.\n\n"
-            "positional arguments:\n"
-            "  image_path            path to the built container image\n\n"
-            f"{argparse_options_line}"
-            "  -h, --help            show this help message and exit\n"
-            "  --base-image BASE_IMAGE\n"
-            "                        base image to use for the container which may be any\n"
-            "                        valid Apptainer/Singularity <BUILD SPEC>\n"
-            "  --system SYSTEM       which system/partition you will be running the\n"
-            "                        container on. This sets base image and other\n"
-            "                        parameters for a simpler container creation. Running\n"
-            "                        the info command will tell you more about the system\n"
-            "                        and what is available\n"
-            "  --conda-env CONDA_ENV\n"
-            "                        path to a Conda environment.yml file to install and\n"
-            "                        activate in the container. When installing a Conda\n"
-            "                        environment, you must accept the Miniforge license\n"
-            "                        terms, as specified during the build process\n"
-            "  --accept-licenses     accept all license terms (if any) needed for\n"
-            "                        completing the container build process\n"
-            "  --verbose, -v         increase the verbosity of the output from cotainr. Can\n"
-            "                        be used multiple times: Once for subprocess output,\n"
-            "                        twice for subprocess INFO, three times for VERBOSE,\n"
-            "                        four times for DEBUG and five times for TRACE.\n"
-            "  --quiet, -q           do not show any non-CRITICAL output from cotainr\n"
-            "  --log-to-file         create files containing all logging information shown\n"
-            "                        on stdout/stderr\n"
-            "  --no-color            do not use colored console output\n"
+        # You can use e.g. `cotainr build --help > a.txt` to generate the
+        # help output in the 80 columns that's defaulted to when
+        # stdout isn't a TTY.
+        assert stdout.strip() == (
+            """
+usage: cotainr build [-h] (--base-image BASE_IMAGE | --system SYSTEM)
+                     [--conda-env CONDA_ENV |
+                     --requirements-txt REQUIREMENTS_TXT] [--accept-licenses]
+                     [--verbose | --quiet] [--log-to-file] [--no-color]
+                     image_path
+
+Build a container.
+
+positional arguments:
+  image_path            path to the built container image
+
+options:
+  -h, --help            show this help message and exit
+  --base-image BASE_IMAGE
+                        base image to use for the container which may be any
+                        valid Apptainer/Singularity <BUILD SPEC>
+  --system SYSTEM       which system/partition you will be running the
+                        container on. This sets base image and other
+                        parameters for a simpler container creation. Running
+                        the info command will tell you more about the system
+                        and what is available
+  --conda-env CONDA_ENV
+                        path to a Conda environment.yml file to install and
+                        activate in the container. When installing a Conda
+                        environment, you must accept the Miniforge license
+                        terms, as specified during the build process
+  --requirements-txt REQUIREMENTS_TXT
+                        path to a requirements.txt file to install in the
+                        container
+  --accept-licenses     accept all license terms (if any) needed for
+                        completing the container build process
+  --verbose, -v         increase the verbosity of the output from cotainr. Can
+                        be used multiple times: Once for subprocess output,
+                        twice for subprocess INFO, three times for VERBOSE,
+                        four times for DEBUG and five times for TRACE.
+  --quiet, -q           do not show any non-CRITICAL output from cotainr
+  --log-to-file         create files containing all logging information shown
+                        on stdout/stderr
+  --no-color            do not use colored console output
+""".strip()
         )
-        target = " ".join(target.split())
-        assert target == stdout

--- a/cotainr/tests/container/data.py
+++ b/cotainr/tests/container/data.py
@@ -7,50 +7,41 @@ Licensed under the European Union Public License (EUPL) 1.2
 
 """
 
+import pathlib
 import subprocess
 
 import pytest
 
 
-@pytest.fixture(scope="session")
-def data_cached_alpine_sif(tmp_path_factory):
-    """A session scope cached SIF image of the latest alpine linux container."""
-    singularity_image_path = (
-        tmp_path_factory.mktemp("singularity_images") / "alpine_latest.sif"
-    )
+def _pull_image(image_name: str, target_path: pathlib.Path) -> pathlib.Path:
     subprocess.run(
         args=[
             "singularity",
             "pull",
-            f"{singularity_image_path.resolve()}",
-            "docker://alpine:latest",
+            f"{target_path}",
+            f"docker://{image_name}",
         ],
         capture_output=True,
         check=True,
         text=True,
     )
-    assert singularity_image_path.exists()
+    assert target_path.exists()
+    return target_path
 
-    return singularity_image_path
+
+@pytest.fixture(scope="session")
+def data_cached_alpine_sif(tmp_path_factory):
+    """A session scope cached SIF image of the latest alpine linux container."""
+    return _pull_image(
+        "alpine:latest",
+        tmp_path_factory.mktemp("singularity_images") / "alpine_latest.sif",
+    )
 
 
 @pytest.fixture(scope="session")
 def data_cached_ubuntu_sif(tmp_path_factory):
     """A session scope cached SIF image of the latest ubuntu linux container."""
-    singularity_image_path = (
-        tmp_path_factory.mktemp("singularity_images") / "ubuntu_latest.sif"
+    return _pull_image(
+        "ubuntu:latest",
+        tmp_path_factory.mktemp("singularity_images") / "ubuntu_latest.sif",
     )
-    subprocess.run(
-        args=[
-            "singularity",
-            "pull",
-            f"{singularity_image_path.resolve()}",
-            "docker://ubuntu:latest",
-        ],
-        capture_output=True,
-        check=True,
-        text=True,
-    )
-    assert singularity_image_path.exists()
-
-    return singularity_image_path

--- a/cotainr/tests/container/data.py
+++ b/cotainr/tests/container/data.py
@@ -45,3 +45,12 @@ def data_cached_ubuntu_sif(tmp_path_factory):
         "ubuntu:latest",
         tmp_path_factory.mktemp("singularity_images") / "ubuntu_latest.sif",
     )
+
+
+@pytest.fixture(scope="session")
+def data_cached_python312_sif(tmp_path_factory):
+    """A session scope cached SIF image of the latest Python 3.12 container."""
+    return _pull_image(
+        "python:3.12-slim",
+        tmp_path_factory.mktemp("singularity_images") / "python312_latest.sif",
+    )

--- a/cotainr/tests/pack/test_conda_install.py
+++ b/cotainr/tests/pack/test_conda_install.py
@@ -557,7 +557,8 @@ class Test_LoggingFilters:
             conda_install = CondaInstall(sandbox=sandbox, license_accepted=True)
 
         filter_names = [
-            filter_.__class__.__name__ for filter_ in conda_install._logging_filters
+            filter_.__class__.__name__
+            for filter_ in conda_install._create_logging_filters()
         ]
         assert filter_names == [
             "StripANSIEscapeCodes",
@@ -573,7 +574,7 @@ class Test_LoggingFilters:
     ):
         with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
             conda_install = CondaInstall(sandbox=sandbox, license_accepted=True)
-            filter_ = conda_install._logging_filters[0]
+            filter_ = conda_install._create_logging_filters()[0]
             assert filter_.__class__.__name__ == "StripANSIEscapeCodes"
 
         rec = logging.LogRecord(
@@ -602,7 +603,7 @@ class Test_LoggingFilters:
     ):
         with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
             conda_install = CondaInstall(sandbox=sandbox, license_accepted=True)
-            filter_ = conda_install._logging_filters[2]
+            filter_ = conda_install._create_logging_filters()[2]
             assert filter_.__class__.__name__ == "NoEmptyLinesFilter"
 
         rec = logging.LogRecord(
@@ -651,7 +652,7 @@ class Test_LoggingFilters:
     ):
         with SingularitySandbox(base_image="my_base_image_6021") as sandbox:
             conda_install = CondaInstall(sandbox=sandbox, license_accepted=True)
-            filter_ = conda_install._logging_filters[1]
+            filter_ = conda_install._create_logging_filters()[1]
             assert filter_.__class__.__name__ == "OnlyFinalProgressbarFilter"
 
         rec = logging.LogRecord(

--- a/cotainr/tests/pack/test_pip_install.py
+++ b/cotainr/tests/pack/test_pip_install.py
@@ -1,0 +1,32 @@
+"""
+cotainr - a user space Apptainer/Singularity container builder.
+
+Copyright DeiC, deic.dk
+Copyright Aarni Koskela
+
+Licensed under the European Union Public License (EUPL) 1.2
+- see the LICENSE file for details.
+
+"""
+
+import pytest
+
+from cotainr.container import SingularitySandbox
+from cotainr.pip import PipInstall
+
+from ..container.data import data_cached_python312_sif  # noqa
+
+
+@pytest.mark.pip_integration
+@pytest.mark.singularity_integration
+@pytest.mark.parametrize("use_uv", [False, True], ids=["vanilla", "uv"])
+def test_env_creation(tmp_path, data_cached_python312_sif, use_uv):
+    requirements_path = tmp_path / "requirements.txt"
+    requirements_path.write_text("six")  # `six` is small enough to be installed quickly
+    with SingularitySandbox(base_image=data_cached_python312_sif) as sandbox:
+        pip_install = PipInstall(sandbox=sandbox, use_uv=use_uv)
+        pip_install.configure(
+            requirements_files=[str(requirements_path)], add_to_env=True
+        )
+        process = sandbox.run_command_in_container(cmd="pip freeze")
+        assert "six==" in process.stdout

--- a/doc/api_reference/index.rst
+++ b/doc/api_reference/index.rst
@@ -10,5 +10,6 @@ The full public cotainr API is listed below.
    cotainr.cli
    cotainr.container
    cotainr.pack
+   cotainr.pip
    cotainr.tracing
    cotainr.util

--- a/doc/user_guide/conda_env.rst
+++ b/doc/user_guide/conda_env.rst
@@ -52,7 +52,12 @@ The conda environment is automatically activated when the container is run, allo
 
 Pip packages
 ------------
-`cotainr` does not support creating a container directly from a `pip requirements.txt <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`_ file. However, `pip packages may be included in a conda environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#using-pip-in-an-environment>`_, e.g. updating `my_conda_env.yml` to
+
+.. seealso::
+
+    - :ref:`pip_environments`
+
+`Pip packages may be included in a conda environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#using-pip-in-an-environment>`_, e.g. updating `my_conda_env.yml` to
 
 .. code-block:: yaml
     :caption: my_conda_env.yml

--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -110,6 +110,7 @@ Use cases
 Typical use cases, that `cotainr` makes very easy to handle, include:
 
 - :ref:`Creating a container based on a Conda environment <conda_environments>`
+- :ref:`Creating a container based on Pip requirements <pip_environments>`
 
 ..
     Toc for the use case pages
@@ -118,6 +119,7 @@ Typical use cases, that `cotainr` makes very easy to handle, include:
     :hidden:
 
     conda_env
+    pip_env
 
 
 Examples

--- a/doc/user_guide/pip_env.rst
+++ b/doc/user_guide/pip_env.rst
@@ -1,0 +1,31 @@
+.. _pip_environments:
+
+Pip Environments
+================
+
+`cotainr` can set up a container to include a Python virtualenv, into which packages are installed using `pip <https://pip.pypa.io/en/stable/>`_.
+This is done by specifying a `pip requirements.txt file <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`_ when building the container.
+
+When using a requirements file, the base image must contain an usable ``python3`` and ``bash``.
+
+For instance, given a requirements file
+
+.. code-block:: text
+    :caption: requirements.txt
+
+    numpy~=2.0
+
+you can build a Python 3.12 container with Numpy 2.x installed with:
+
+.. code-block:: console
+
+    $ cotainr build my_fresh_numpy.sif --base-image=docker://python:3.12-slim --requirements-txt=requirements.txt
+
+The virtualenv (located at ``/opt/venv``) is automatically activated when the container is run, allowing for directly using the packages installed.
+
+.. code-block:: console
+
+    $ singularity exec my_fresh_numpy.sif python3 --version
+    Python 3.12.3
+    $ singularity exec my_fresh_numpy.sif python3 -c "import numpy; print(numpy.__version__)"
+    2.xx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,5 +184,6 @@ junit_suite_name = "cotainr_test_suite"
 markers = [
     "conda_integration: marks tests of integration with conda/mamba",
     "endtoend: marks end-to-end test cases",
+    "pip_integration: marks tests of integration with pip",
     "singularity_integration: marks tests of integration with singularity",
 ]


### PR DESCRIPTION
The main meat of this PR is `PipInstall`, a sibling of `CondaInstall` that runs `venv` (or `uv venv`) and `pip install` (or `uv pip install`) to install requirements from `requirements.txt` files.

The base image needs to have a `python3` on `PATH` for this to work at all, of course.

As alluded to above, this also includes support for the [uv](https://github.com/astral-sh/uv) package installer as a faster alternative to `pip`; this is enabled by the currently-undocumented `COTAINR_USE_UV` environment variable being set to a non-empty value.

All tests, old and new, pass locally (using a dockerized singularity since I'm on a Mac).