### PR TITLE
Set up standard Python packaging

### DIFF
--- a/.github/workflows/CI_pull_request.yml
+++ b/.github/workflows/CI_pull_request.yml
@@ -16,6 +16,17 @@ jobs:
         with:
           python-version: "3.x"
       - uses: pre-commit/action@v3.0.1
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
   run-full-test-suite:
     name: Run full test suite
     runs-on: ${{ matrix.os }}
@@ -59,11 +70,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: "**/test-requirements.txt"
       - name: Install test dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install -r test-requirements.txt
+          python3 -m pip install -e .[tests]
       - name: Run test suite via pytest
         run: pytest -vv --junitxml=pytest_junit_out.xml
       - name: Archive the test results and coverage

--- a/.github/workflows/CI_push.yml
+++ b/.github/workflows/CI_push.yml
@@ -30,10 +30,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: "**/test-requirements.txt"
       - name: Install test dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install -r test-requirements.txt
+          python3 -m pip install -e .[tests]
       - name: Run unittests via pytest
         run: pytest -vv -m "not endtoend and not singularity_integration and not conda_integration"

--- a/.github/workflows/SCHED_docs_linkcheck.yml
+++ b/.github/workflows/SCHED_docs_linkcheck.yml
@@ -18,11 +18,10 @@ jobs:
         with:
           python-version: '3.x'
           cache: pip
-          cache-dependency-path: "**/docs-requirements.txt"
       - name: Install docs dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install -r docs-requirements.txt
+          python3 -m pip install -e .[docs]
       - name: Build documentation
         run: |
           make -C doc apidoc

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,4 +16,6 @@ sphinx:
   fail_on_warning: true
 python:
   install:
-  - requirements: docs-requirements.txt
+  - path: .
+    extra_requirements:
+      - docs

--- a/bin/cotainr
+++ b/bin/cotainr
@@ -8,6 +8,9 @@ import sys
 from pathlib import Path
 
 if __name__ == "__main__":
+    # Preferably use the `cotainr` entrypoint defined in pyproject.toml, but this
+    # works for a "source install".
+
     sys.path.insert(0, (Path(__file__) / "../..").resolve().as_posix())
     from cotainr.cli import main
 

--- a/doc/development/cli_internals.rst
+++ b/doc/development/cli_internals.rst
@@ -7,12 +7,15 @@ The `cotainr` command line interface is designed around a subcommand for each ma
 
 The CLI is build using :mod:`argparse`.
 
-The main way to invoke the CLI (sub)commands is via the `bin/cotainr` script, e.g.
+The main way to invoke the CLI (sub)commands in an HPC environment is via the `bin/cotainr` script, e.g.
 
 .. code-block:: console
 
     $ ./bin/cotainr build <positional_arg> <non-positional args>
     $ ./bin/cotainr info
+
+The CLI (sub)commands may also be executed via the `cotainr` entrypoint that is installed when installing the package;
+substitute ``cotainr`` instead of ``./bin/cotainr``.
 
 Implementation of command line interface
 ----------------------------------------

--- a/doc/development/documentation.rst
+++ b/doc/development/documentation.rst
@@ -23,9 +23,8 @@ The HTML version of the documentation is based on the `PyData Spinx Theme <https
 
 Dependencies
 ~~~~~~~~~~~~
-In order to build the HTML version of the documentation, you must have the Python packages listed the `docs-requirements.txt <https://github.com/DeiC-HPC/cotainr/blob/main/docs-requirements.txt>`_ installed, i.e.
 
-.. include:: ../../docs-requirements.txt
-    :literal:
+In order to build the HTML version of the documentation, you must have the Python packages listed in the `docs` extra.
+You can use ``pip install -e .[docs]`` to install the required packages.
 
 Also, in order to run the above :code:`make` commands, you muse have `make <https://www.gnu.org/software/make/>`_ installed.

--- a/doc/development/test_suite_ci_cd.rst
+++ b/doc/development/test_suite_ci_cd.rst
@@ -16,11 +16,8 @@ The `cotainr` test suite is implemented using `pytest <https://docs.pytest.org/>
 
 Dependencies
 ~~~~~~~~~~~~
-In order to run the tests, you must have the Python packages listed in `test-requirements.txt <https://github.com/DeiC-HPC/cotainr/blob/main/test-requirements.txt>`_ installed, i.e.
-
-.. include:: ../../test-requirements.txt
-    :literal:
-
+In order to run the tests, you must have the Python packages listed in the `test` extra.
+You can use ``pip install -e .[tests]`` to install the required packages.
 
 Pytest marks
 ~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools >= 61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "cotainr"
-version = "2024.10.0"
+dynamic = ["version"]
 dependencies = []
 requires-python = ">=3.8"
 authors = [
@@ -23,7 +23,8 @@ maintainers = [
 ]
 description = "A user space Apptainer/Singularity container builder"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "EUPL-1.2"
+license-files = { paths = ["LICENSE"] }
 keywords = ["hpc", "container", "singularity", "apptainer", "conda"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -70,6 +71,9 @@ Documentation = "https://cotainr.readthedocs.io/en/stable/"
 Repository = "https://github.com/DeiC-HPC/cotainr.git"
 "Bug Tracker" = "https://github.com/DeiC-HPC/cotainr/issues"
 Changelog = "https://cotainr.readthedocs.io/en/stable/release_notes/index.html"
+
+[tool.hatch.version]
+path = "cotainr/__init__.py"
 
 [tool.ruff]
 target-version = "py38"
@@ -138,7 +142,7 @@ testpaths = [
 junit_suite_name = [
     "cotainr_test_suite",
 ]
-markers =[
+markers = [
     "conda_integration: marks tests of integration with conda/mamba",
     "endtoend: marks end-to-end test cases",
     "singularity_integration: marks tests of integration with singularity",


### PR DESCRIPTION
This PR sets up modern standard Python packaging using [Hatch](https://hatch.pypa.io/)'s Hatchling build backend.

Major changes are:

* ~the introduction of a standard `pyproject.toml` file~ Done via #107
* `cotainr` now has [a standard console script entrypoint](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#console-scripts), so `bin/cotainr` is no longer technically needed 
* ~extra requirements (`test`, `docs`) are now specified in the `pyproject.toml` file (so installable via `pip install -e .[test,docs]`)~ Done via #107

This makes Cotainr installable and available directly via e.g.

```
pip install git+https://github.com/DeiC-HPC/cotainr.git
```
(or a built wheel – there's a GHA workflow for that too):

```
~ $ docker run -it python:3.12 bash
root@27974cb842d6:/# pip install git+https://github.com/akx/cotainr.git@packaging
Collecting git+https://github.com/akx/cotainr.git@packaging
Successfully built cotainr
Installing collected packages: cotainr
Successfully installed cotainr-2023.11.0
root@27974cb842d6:/# cotainr
usage: cotainr [-h] {build,info} ...

Build Apptainer/Singularity containers for HPC systems in user space.

options:
  -h, --help    show this help message and exit

subcommands:
  {build,info}
    build       Build a container.
    info        Obtain info about the state of all required dependencies for building a container.
root@27974cb842d6:/#
```

Please see https://github.com/akx/cotainr/pull/1 for CI results in my fork.
