### PR TITLE
Follow-up on CI & lint stuff

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Run ruff-format
+7880ea89fa9aed1e443696bb6042f90613ee5bf1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.9.9
     hooks:
       - id: ruff
         args:

--- a/bin/cotainr
+++ b/bin/cotainr
@@ -4,8 +4,8 @@
 # Licensed under the European Union Public License (EUPL) 1.2
 # - see the LICENSE file for details.
 
-import sys
 from pathlib import Path
+import sys
 
 if __name__ == "__main__":
     # Preferably use the `cotainr` entrypoint defined in pyproject.toml, but this

--- a/cotainr/__init__.py
+++ b/cotainr/__init__.py
@@ -21,8 +21,12 @@ _minimum_dependency_version = {
 
 # Error early on too old Python version
 if sys.version_info < _minimum_dependency_version["python"]:
+    # Note that this is using percent formatting on purpose, so this
+    # file can be executed by Python versions older than the minimum
+    # for Cotainr in general; this includes being able to run with
+    # Python 2.7!
     sys.exit(
-        (
+        (  # noqa: UP031
             "\x1b[38;5;160m"  # start of red colored text
             "Cotainr requires Python>=%s\n"
             "You are running Python==%s\n"

--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -502,7 +502,7 @@ class CotainrCLI:
 
     def _setup_cotainr_cli_logging(self, *, log_settings):
         """
-        Setup logging for the cotainr main CLI.
+        Set up logging for the cotainr main CLI.
 
         Setting up the logging for the cotainr main CLI includes:
         - Defining log levels based on CLI verbosity arguments.

--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -38,12 +38,9 @@ import subprocess
 import sys
 import time
 
-from . import container
-from . import pack
-from . import tracing
-from . import util
-from . import _minimum_dependency_version as _min_dep_ver
 from . import __version__ as _cotainr_version
+from . import _minimum_dependency_version as _min_dep_ver
+from . import container, pack, tracing, util
 
 logger = logging.getLogger(__name__)
 

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -312,6 +312,7 @@ class SingularitySandbox:
     def _create_file(self, *, f):
         """
         Create any file `f` in an existing folder in the Singularity container.
+
         The file permissions will ignore the system umask.
 
         Parameters

--- a/cotainr/container.py
+++ b/cotainr/container.py
@@ -23,8 +23,7 @@ import sys
 from tempfile import TemporaryDirectory
 
 from . import __version__ as _cotainr_version
-from . import tracing
-from . import util
+from . import tracing, util
 
 logger = logging.getLogger(__name__)
 

--- a/cotainr/pack.py
+++ b/cotainr/pack.py
@@ -437,9 +437,7 @@ class CondaInstall:
                 return True
 
         class NoEmptyLinesFilter(logging.Filter):
-            """
-            Remove any empty lines.
-            """
+            """Remove any empty lines."""
 
             def filter(self, record):
                 return record.msg.strip() != ""

--- a/cotainr/pack.py
+++ b/cotainr/pack.py
@@ -23,8 +23,7 @@ import time
 import urllib.error
 import urllib.request
 
-from . import tracing
-from . import util
+from . import tracing, util
 
 logger = logging.getLogger(__name__)
 

--- a/cotainr/tests/cli/test_build.py
+++ b/cotainr/tests/cli/test_build.py
@@ -15,11 +15,12 @@ import shlex
 import pytest
 
 from cotainr.cli import Build, CotainrCLI
+
 from ..container.patches import (
-    patch_save_singularity_sandbox_context,
-    patch_fake_singularity_sandbox_env_folder,
-    patch_disable_singularity_sandbox_subprocess_runner,
     patch_disable_add_metadata,
+    patch_disable_singularity_sandbox_subprocess_runner,
+    patch_fake_singularity_sandbox_env_folder,
+    patch_save_singularity_sandbox_context,
 )
 from ..pack.patches import (
     patch_disable_conda_install_bootstrap_conda,
@@ -27,7 +28,7 @@ from ..pack.patches import (
     patch_disable_conda_install_download_miniforge_installer,
 )
 from ..tracing.patches import patch_disable_console_spinner
-from ..util.patches import patch_system_with_actual_file, patch_empty_system
+from ..util.patches import patch_empty_system, patch_system_with_actual_file
 
 
 class TestConstructor:

--- a/cotainr/tests/cli/test_cotainr_cli.py
+++ b/cotainr/tests/cli/test_cotainr_cli.py
@@ -15,6 +15,7 @@ import pytest
 
 from cotainr.cli import CotainrCLI
 from cotainr.tracing import LogSettings
+
 from .data import (
     data_cotainr_critical_color_log_messages,
     data_cotainr_debug_color_log_messages,
@@ -25,7 +26,7 @@ from .patches import (
     patch_disable_cotainrcli_init,
     patch_disables_cotainrcli_setup_cotainr_cli_logging,
 )
-from .stubs import StubValidSubcommand, StubInvalidSubcommand, StubLogSettingsSubcommand
+from .stubs import StubInvalidSubcommand, StubLogSettingsSubcommand, StubValidSubcommand
 
 
 class TestConstructor:

--- a/cotainr/tests/cli/test_info.py
+++ b/cotainr/tests/cli/test_info.py
@@ -14,6 +14,7 @@ import subprocess
 import pytest
 
 from cotainr.cli import CotainrCLI, Info
+
 from ..util.patches import patch_empty_system, patch_system_with_actual_file
 
 

--- a/cotainr/tests/cli/test_main.py
+++ b/cotainr/tests/cli/test_main.py
@@ -8,6 +8,7 @@ Licensed under the European Union Public License (EUPL) 1.2
 """
 
 import cotainr.cli
+
 from .stubs import StubDummyCLI
 
 

--- a/cotainr/tests/conftest.py
+++ b/cotainr/tests/conftest.py
@@ -8,9 +8,9 @@ Licensed under the European Union Public License (EUPL) 1.2
 """
 
 import contextlib
-import logging
 import importlib
 import io
+import logging
 import os
 from pathlib import Path
 import shlex

--- a/cotainr/tests/container/patches.py
+++ b/cotainr/tests/container/patches.py
@@ -88,7 +88,6 @@ def patch_save_singularity_sandbox_context(monkeypatch):
     The content on `SingularitySandbox.sandbox_dir` is copied to
     `saved_sandbox_dir` before being cleaned up.
     """
-
     saved_sandbox_dir_name = "saved_sandbox_dir"
 
     def mock_exit(self, exc_type, exc_value, traceback):
@@ -114,7 +113,6 @@ def patch_disable_add_metadata(monkeypatch):
     """
     Disable SingularitySandbox.add_metadata().
     """
-
     monkeypatch.setattr(
         cotainr.container.SingularitySandbox, "add_metadata", lambda _: None
     )

--- a/cotainr/tests/container/test_singularity_sandbox.py
+++ b/cotainr/tests/container/test_singularity_sandbox.py
@@ -14,9 +14,10 @@ import pytest
 
 from cotainr.container import SingularitySandbox
 from cotainr.tracing import LogDispatcher, LogSettings
+
+from ..util.patches import patch_disable_stream_subprocess
 from .data import data_cached_alpine_sif
 from .patches import patch_fake_singularity_sandbox_env_folder
-from ..util.patches import patch_disable_stream_subprocess
 
 
 class TestConstructor:

--- a/cotainr/tests/pack/patches.py
+++ b/cotainr/tests/pack/patches.py
@@ -11,7 +11,6 @@ import sys
 
 import pytest
 
-
 import cotainr.pack
 
 

--- a/cotainr/tests/pack/test_conda_install.py
+++ b/cotainr/tests/pack/test_conda_install.py
@@ -168,14 +168,12 @@ class TestCleanupUnusedFiles:
         with SingularitySandbox(base_image=data_cached_ubuntu_sif) as sandbox:
             CondaInstall(sandbox=sandbox, license_accepted=True)
             process = sandbox.run_command_in_container(cmd="conda clean -d -a")
-            clean_msg = "\n".join(
-                [
-                    "There are no unused tarball(s) to remove.",
-                    "There are no index cache(s) to remove.",
-                    "There are no unused package(s) to remove.",
-                    "There are no tempfile(s) to remove.",
-                    "There are no logfile(s) to remove.",
-                ]
+            clean_msg = (
+                "There are no unused tarball(s) to remove.\n"
+                "There are no index cache(s) to remove.\n"
+                "There are no unused package(s) to remove.\n"
+                "There are no tempfile(s) to remove.\n"
+                "There are no logfile(s) to remove."
             )
             assert process.stdout.strip() == clean_msg
 

--- a/cotainr/tests/pack/test_conda_install.py
+++ b/cotainr/tests/pack/test_conda_install.py
@@ -8,23 +8,24 @@ Licensed under the European Union Public License (EUPL) 1.2
 """
 
 import logging
+import platform
 import re
 import subprocess
 import urllib.error
-import platform
 
 import pytest
 
 from cotainr.container import SingularitySandbox
 from cotainr.pack import CondaInstall
 from cotainr.tracing import LogSettings
+
+from ..container.data import data_cached_ubuntu_sif
+from ..container.patches import patch_disable_singularity_sandbox_subprocess_runner
 from .patches import (
     patch_disable_conda_install_bootstrap_conda,
     patch_disable_conda_install_download_miniforge_installer,
 )
 from .stubs import StubEmptyLicensePopen, StubShowLicensePopen
-from ..container.data import data_cached_ubuntu_sif
-from ..container.patches import patch_disable_singularity_sandbox_subprocess_runner
 
 
 class TestConstructor:

--- a/cotainr/tests/test__main__.py
+++ b/cotainr/tests/test__main__.py
@@ -13,8 +13,9 @@ import sys
 
 import pytest
 
-from .cli.patches import patch_disable_main
 import cotainr
+
+from .cli.patches import patch_disable_main
 
 
 class Test__main__:

--- a/cotainr/tests/test_end_to_end.py
+++ b/cotainr/tests/test_end_to_end.py
@@ -11,8 +11,9 @@ import shlex
 
 import pytest
 
-from cotainr.cli import CotainrCLI
 from cotainr import __version__ as _cotainr_version
+from cotainr.cli import CotainrCLI
+
 from .container.data import data_cached_ubuntu_sif
 
 

--- a/cotainr/tests/tracing/patches.py
+++ b/cotainr/tests/tracing/patches.py
@@ -12,6 +12,7 @@ import contextlib
 import pytest
 
 import cotainr.tracing
+
 from .stubs import FixedNumberOfSpinsEvent
 
 

--- a/cotainr/tests/tracing/test_console_spinner.py
+++ b/cotainr/tests/tracing/test_console_spinner.py
@@ -13,6 +13,7 @@ import sys
 import pytest
 
 from cotainr.tracing import ConsoleSpinner, StreamWriteProxy, console_lock
+
 from .patches import patch_fix_number_of_message_spins
 from .stubs import RaiseOnEnterContext
 

--- a/cotainr/tests/tracing/test_message_spinner.py
+++ b/cotainr/tests/tracing/test_message_spinner.py
@@ -14,6 +14,7 @@ import time
 import pytest
 
 from cotainr.tracing import MessageSpinner
+
 from .stubs import FixedNumberOfSpinsEvent
 
 

--- a/cotainr/tests/util/test_get_systems.py
+++ b/cotainr/tests/util/test_get_systems.py
@@ -8,13 +8,15 @@ Licensed under the European Union Public License (EUPL) 1.2
 """
 
 import pytest
+
+import cotainr.util
+
 from .patches import (
     patch_empty_system,
     patch_system_with_actual_file,
-    patch_system_with_non_existing_file,
     patch_system_with_badly_formatted_file,
+    patch_system_with_non_existing_file,
 )
-import cotainr.util
 
 
 class TestGetSystems:

--- a/cotainr/tests/util/test_stream_subprocess.py
+++ b/cotainr/tests/util/test_stream_subprocess.py
@@ -17,7 +17,7 @@ import sys
 import pytest
 
 from cotainr.tracing import LogDispatcher, LogSettings
-from cotainr.util import stream_subprocess, _print_and_capture_stream
+from cotainr.util import _print_and_capture_stream, stream_subprocess
 
 
 class TestStreamSubprocess:

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -146,7 +146,7 @@ class ConsoleSpinner:
 
     def __enter__(self):
         """
-        Setup the console spinner context.
+        Set up the console spinner context.
 
         Returns
         -------
@@ -226,7 +226,7 @@ class ConsoleSpinner:
 
     def _thread_safe_input(self, input_func):
         """
-        A decorator to make input stop spinning messages.
+        Decorate a function to make input stop spinning messages.
 
         Stops the spinning message prior to calling the :py:func:`input` such
         that the spinning message doesn't interfere with the user input.
@@ -299,7 +299,7 @@ class LogDispatcher:
         log_settings,
         filters=None,
     ):
-        """Setup the log dispatcher."""
+        """Set up the log dispatcher."""
         self.map_log_level = map_log_level_func
         self.verbosity = log_settings.verbosity
         self.log_file_path = log_settings.log_file_path
@@ -389,7 +389,7 @@ class LogDispatcher:
     @contextlib.contextmanager
     def prefix_stderr_name(self, *, prefix):
         """
-        A context manager for prefixing the `stderr` logger name.
+        Manage a context to prefix the `stderr` logger name.
 
         When inside the context, the name of the `stderr` logger is changed to
         be prefixed by "`prefix`/".
@@ -534,7 +534,7 @@ class MessageSpinner:
         self._running = True
 
     def stop(self):
-        """Stop the message spinner thread"""
+        """Stop the message spinner thread."""
         if self._running:
             self._stop_signal.set()
             self._spinner_thread.join()
@@ -610,13 +610,17 @@ class StreamWriteProxy:
 
     def write(self, s, /):
         """
-        Write a string to the stream using the true `stream.write` method and
-        return the number of characters written.
+        Write a string to the stream using the true `stream.write` method.
 
         Parameters
         ----------
         s : str
             The string to write.
+
+        Returns
+        -------
+        int
+            The number of characters written.
         """
         return self.true_stream_write(s)
 

--- a/cotainr/tracing.py
+++ b/cotainr/tracing.py
@@ -29,8 +29,8 @@ console_lock
 """
 
 import builtins
-import copy
 import contextlib
+import copy
 import dataclasses
 import functools
 import itertools

--- a/cotainr/util.py
+++ b/cotainr/util.py
@@ -165,7 +165,8 @@ def _print_and_capture_stream(*, stream_handle, print_dispatch):
 def _flush_stdin_buffer():
     """
     Discard queued data on stdin file descriptor.
-    TCIOFLUSH selects both the input queue and output queue to be discarded
+
+    TCIOFLUSH selects both the input queue and output queue to be discarded.
 
     https://stackoverflow.com/questions/2520893/how-to-flush-the-input-stream
     """

--- a/cotainr/util.py
+++ b/cotainr/util.py
@@ -22,8 +22,8 @@ systems_file
 
 from concurrent.futures import ThreadPoolExecutor
 import functools
-import logging
 import json
+import logging
 from pathlib import Path
 import subprocess
 import sys
@@ -178,6 +178,6 @@ def _flush_stdin_buffer():
         return
 
     # Python Standard library, Linux/Unix/OSX
-    from termios import tcflush, TCIOFLUSH
+    from termios import TCIOFLUSH, tcflush
 
     tcflush(sys.stdin, TCIOFLUSH)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -116,15 +116,12 @@ html_theme_options = {
 
 
 def add_api_headline_to_module_docs(app, what, name, obj, options, lines):
-    """
-    Event for adding a 'API reference' headline before showing API content in
-    auto modules.
-    """
+    """Add an 'API reference' headline before showing API content in auto modules."""
     if what == "module":
         lines.append("\n")
         lines.append("API reference")
         lines.append("-------------")
 
 
-def setup(app):
+def setup(app):  # noqa: D103
     app.connect("autodoc-process-docstring", add_api_headline_to_module_docs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ lint.extend-select = [
     "B", # flake8-bugbear
     "E", # pycodestyle errors
     "F", # Pyflakes
+    "I", # import ordering
     "W", # pycodestyle warnings
 ]
 # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
@@ -108,6 +109,9 @@ lint.exclude = [
 "cotainr/tests/**.py" = [
     "S101", # assertions are OK in tests
 ]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ line-length = 88
 
 lint.extend-select = [
     "B", # flake8-bugbear
+    "D", # docstrings
     "E", # pycodestyle errors
     "F", # Pyflakes
     "I", # import ordering
@@ -106,8 +107,15 @@ lint.exclude = [
     "F401",
     "F811",
 ]
+"examples/**.py" = [
+    "D",  # docstring formatting doesn't matter that much
+]
 "cotainr/tests/**.py" = [
+    "D",  # docstring formatting doesn't matter that much
     "S101", # assertions are OK in tests
+]
+"bin/cotainr" = [
+    "D",  # docstring formatting doesn't matter that much
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ lint.extend-select = [
     "D", # docstrings
     "E", # pycodestyle errors
     "F", # Pyflakes
+    "FLY", # F-strings
     "I", # import ordering
     "UP", # pyupgrade
     "W", # pycodestyle warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ lint.extend-select = [
     "E", # pycodestyle errors
     "F", # Pyflakes
     "I", # import ordering
+    "UP", # pyupgrade
     "W", # pycodestyle warnings
 ]
 # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules


### PR DESCRIPTION
The promised follow-up to #56 (one of them, anyway).

This enables some of the rule categories discussed in https://github.com/DeiC-HPC/cotainr/pull/56#discussion_r1746722406.

E.g. selecting `S` (bandit, i.e. security) flags practically all uses of `subprocess.run`, which there are many, so that's elided from here.
