### PR TITLE
An attempt at handling problems with hitting rate limits in docs link…

### DIFF
--- a/.github/workflows/SCHED_docs_linkcheck.yml
+++ b/.github/workflows/SCHED_docs_linkcheck.yml
@@ -29,4 +29,6 @@ jobs:
           make -C doc relnotes
           make -C doc html
       - name: Run Sphinx linkcheck on documentation
-        run: make -C doc linkcheck || make -C doc linkcheck || make -C doc linkcheck  # simple "retry 3 times" - for flaky links
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make -C doc linkcheck

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -57,7 +57,7 @@ if "GITHUB_TOKEN" in os.environ:
     # Authenticate with GitHub token in GitHub Actions to avoid rate limits
     # It is not entirely clear if this has any effect, though...
     linkcheck_request_headers = {
-        "https://github.com": {"Authorization:" f"token {os.environ['GITHUB_TOKEN']}"}
+        "https://github.com": {"Authorization": f"token {os.environ['GITHUB_TOKEN']}"}
     }
 
 # -- Options for HTML output -------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,14 +48,15 @@ numpydoc_class_members_toctree = False
 # -- Options for linkcheck ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
 linkcheck_retries = 3  # Retry 3 times before considering a link broken
+linkcheck_workers = 1  # Limit the number of workers to avoid hitting rate limits
 linkcheck_ignore = [
     # It is easy to hit the rate limit of stackoverflow
     # Let's assume that stackoverflows does not move its supposedly permanent links
     "https://stackoverflow.com",
 ]
 if "GITHUB_TOKEN" in os.environ:
-    # Authenticate with GitHub token in GitHub Actions to avoid rate limits
-    # It is not entirely clear if this has any effect, though...
+    # Authenticate with GitHub token in GitHub Actions to avoid hitting rate limits
+    # It is not entirely clear if this has any effect outside of api.github.com, though...
     linkcheck_request_headers = {
         "https://github.com": {"Authorization": f"token {os.environ['GITHUB_TOKEN']}"}
     }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,6 +45,21 @@ templates_path = ["_templates"]
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 numpydoc_class_members_toctree = False
 
+# -- Options for linkcheck ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
+linkcheck_retries = 3  # Retry 3 times before considering a link broken
+linkcheck_ignore = [
+    # It is easy to hit the rate limit of stackoverflow
+    # Let's assume that stackoverflows does not move its supposedly permanent links
+    "https://stackoverflow.com",
+]
+if "GITHUB_TOKEN" in os.environ:
+    # Authenticate with GitHub token in GitHub Actions to avoid rate limits
+    # It is not entirely clear if this has any effect, though...
+    linkcheck_request_headers = {
+        "https://github.com": {"Authorization:" f"token {os.environ['GITHUB_TOKEN']}"}
+    }
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,6 +53,10 @@ linkcheck_ignore = [
     # It is easy to hit the rate limit of stackoverflow
     # Let's assume that stackoverflows does not move its supposedly permanent links
     "https://stackoverflow.com",
+    # Its also easy to hit the rate limit of github
+    # We do have quite a lot of links to our own github repo
+    # For now, let's avoid checking these
+    "https://github.com/DeiC-HPC/cotainr",
 ]
 if "GITHUB_TOKEN" in os.environ:
     # Authenticate with GitHub token in GitHub Actions to avoid hitting rate limits

--- a/doc/development/test_suite_ci_cd.rst
+++ b/doc/development/test_suite_ci_cd.rst
@@ -89,7 +89,7 @@ The following CI `workflows <https://docs.github.com/en/actions/using-workflows/
 
 Continuous Delivery (CD)
 ------------------------
-Continuous Delivery (CD) is handled partly via `GitHub Actions <https://docs.github.com/en/actions>`_, partly via the a `Read the Docs webhook integration <https://docs.readthedocs.io/en/stable/integrations.html>`_ to the `cotainr` GitHub repository: https://github.com/DeiC-HPC/cotainr/.
+Continuous Delivery (CD) is handled partly via `GitHub Actions <https://docs.github.com/en/actions>`_, partly via the a `Read the Docs webhook integration <https://docs.readthedocs.io/en/stable/continuous-deployment.html>`_ to the `cotainr` GitHub repository: https://github.com/DeiC-HPC/cotainr/.
 
 Read the Docs continuous documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is an attempt at fixing the failing docs linkcheck GitHub action workflow. It includes the following fixes:

- The Read the Docs web hook integration page has been moved. The link has been updated.
- Checks of stackoverflow.com links hit rate limits. We ignore stackoverflow in the checks and assume that they don't move around their supposedly permanent links - and that we don't misspell them...
- Checks of github.com links hit rate limits. We authenticate using the GH Action authentication token in the hope that it raises the rate limit. It is unclear, though, if this makes any difference for github.com - [the documentation only mentions the GitHub REST API (api.github.com)](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-github_token-in-github-actions). As this is apparently not enough, we have, for now, also disabled checks for links to the cotainr GH repo - this should probably be revisited at some time - but for now it is unclear if the rate limits we are hitting is a temporary problem with GitHub (as indicated by https://github.com/orgs/community/discussions/141004 and https://github.com/orgs/community/discussions/141073) or a persistent problem, we need to solve.