### PR TITLE
Make file creation behavior of add_to_env clear

### DIFF
--- a/cotainr/cli.py
+++ b/cotainr/cli.py
@@ -238,6 +238,7 @@ class Build(CotainrSubcommand):
                     conda_install.add_environment(
                         path=conda_env_file, name=conda_env_name
                     )
+
                     sandbox.add_to_env(shell_script=f"conda activate {conda_env_name}")
 
                     # Clean-up unused files

--- a/cotainr/tests/cli/test_build.py
+++ b/cotainr/tests/cli/test_build.py
@@ -378,6 +378,7 @@ class TestExecute:
             conda_bootstrap_cmd,
             conda_bootstrap_clean_cmd,
             conda_env_create_cmd,
+            touch_sourced_env_cmd,
             conda_clean_cmd,
             sandbox_build_cmd,
         ) = capsys.readouterr().out.strip().split("\n")


### PR DESCRIPTION
Here I create `_create_env_path()` to clearly handle file creation, it is inside add_to_env to preserve behavior of tests.

Closes #78 