### PR TITLE
Update 3.8 reqs to 3.9

### DIFF
--- a/.github/workflows/CI_pull_request.yml
+++ b/.github/workflows/CI_pull_request.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         singularity: [
           {provider: "singularity", version: "3.8.7"},
 #          {provider: "apptainer", version: "1.1.3"},
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04-arm"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         singularity: [
           {provider: "apptainer", version: "latest"}
           ]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Our documentation is hosted [here on Read the Docs](https://cotainr.readthedocs.
 
 ## Installation
 
-cotainr has no external dependencies other than Python >= 3.8 and Singularity/Apptainer.
+cotainr has no external dependencies other than Python >= 3.9 and Singularity/Apptainer.
 This means that a release can be unpacked and run directly from the `bin/` directory.
 
 ### Easybuild

--- a/cotainr/__init__.py
+++ b/cotainr/__init__.py
@@ -13,7 +13,7 @@ __version__ = "2024.10.0"
 _minimum_dependency_version = {
     # Versions must be specified as a (major, minor, patchlevel) tuple of
     # integers
-    "python": (3, 8, 0),
+    "python": (3, 9, 0),
     "apptainer": (1, 0, 0),
     "singularity": (3, 7, 4),
     "singularity-ce": (3, 9, 2),

--- a/cotainr/tests/cli/test_info.py
+++ b/cotainr/tests/cli/test_info.py
@@ -98,7 +98,7 @@ class TestHelpMessage:
 
 class Test_check_python_dependency:
     def test_formatting(self):
-        # Check for formatting like "Running python 3.11.0 >= 3.8.0, OK"
+        # Check for formatting like "Running python 3.11.0 >= 3.9.0, OK"
         assert re.match(
             (
                 r"^Running python \d+\.\d+\.\d+ (>=)|(<) \d+\.\d+\.\d+, "
@@ -172,10 +172,10 @@ class Test_check_version:
     @pytest.mark.parametrize(
         "version,min_version,cmp_result",
         [
-            ((3, 8, 0), (3, 8, 0), ">= 3.8.0, \x1b[38;5;2mOK\x1b[0m"),
+            ((3, 9, 0), (3, 9, 0), ">= 3.9.0, \x1b[38;5;2mOK\x1b[0m"),
             ((0, 1, 12), (0, 0, 1), ">= 0.0.1, \x1b[38;5;2mOK\x1b[0m"),
-            ((3, 7, 14), (3, 8, 0), "< 3.8.0, \x1b[38;5;1mERROR\x1b[0m"),
-            ((1, 0, 0), (3, 8, 0), "< 3.8.0, \x1b[38;5;1mERROR\x1b[0m"),
+            ((3, 7, 14), (3, 9, 0), "< 3.9.0, \x1b[38;5;1mERROR\x1b[0m"),
+            ((1, 0, 0), (3, 9, 0), "< 3.9.0, \x1b[38;5;1mERROR\x1b[0m"),
         ],
     )
     def test_version_comparison(self, version, min_version, cmp_result):

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -19,7 +19,7 @@ In order to get started using `cotainr`, you need to download and install the `c
             :animate: fade-in
             :color: secondary
 
-            `cotainr` only runs on Linux and requires that `Python`_ >=3.8 as well as `Singularity`_ >=3.7.4 [#]_ or `Apptainer`_ >=1.0.0 is installed on the system. More details about dependencies may be found in the :ref:`User Guide <cotainr_dependencies>`.
+            `cotainr` only runs on Linux and requires that `Python`_ >=3.9 as well as `Singularity`_ >=3.7.4 [#]_ or `Apptainer`_ >=1.0.0 is installed on the system. More details about dependencies may be found in the :ref:`User Guide <cotainr_dependencies>`.
 
             To install `cotainr`, download and unpack the source code. Then add the :code:`cotainr/bin` directory to your :code:`PATH` to get access to the :ref:`cotainr command line interface <command_line_interface>`.
 

--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -23,7 +23,7 @@ Dependencies
 Since `cotainr` is a tool, written in `Python`_, for building `Singularity`_/`Apptainer`_ containers, you need the following to be able to use `cotainr`:
 
 - A Linux OS (since `Singularity`_/`Apptainer`_ `only runs on Linux <https://apptainer.org/docs/admin/main/installation.html#installation-on-linux>`_)
-- `Python`_ >=3.8
+- `Python`_ >=3.9
 - `Singularity`_ >=3.7.4 [#]_ or `Apptainer`_ >=1.0.0
 - An architecture that is either `x86_64 <https://en.wikipedia.org/wiki/X86-64>`_ or `ARM64/AArch64 <https://en.wikipedia.org/wiki/AArch64>`_
 
@@ -80,7 +80,7 @@ This will provide you information about the system and also providing you with n
     $ cotainr info
     Dependency report
     -------------------------------------------------------------------------------
-        - Running python 3.10.8 >= 3.8.0, OK
+        - Running python 3.10.8 >= 3.9.0, OK
         - Found singularity 3.8.7 >= 3.7.4, OK
 
     System info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ Changelog = "https://cotainr.readthedocs.io/en/stable/release_notes/index.html"
 path = "cotainr/__init__.py"
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 88
 
 lint.extend-select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "cotainr"
 dynamic = ["version"]
 dependencies = []
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     {name = "Christian Schou Oxvig"},
     {name = "René Løwe Jacobsen"},
@@ -32,7 +32,6 @@ classifiers = [
     #"Topic :: Software Development :: HPC Tools",
     "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This PR bumps the minimum required version of Python for running cotainr to 3.9. The previous minimum required version [3.8 reached end-of-life on 2024-10-07](https://devguide.python.org/versions/).

Find all references to Python 3.8 using `grep -rnF -e "3.8" -e "3, 8" ./ --exclude-dir=examples/ --exclude-dir=_build/ --exclude-dir=__pycache__/ --exclude-dir=dist/ --exclude-dir=.pytest_cache/` and change the relevant ones to reference Python 3.9.

Additionally, update the Ruff `target-version` to `py39` in the `pyproject.toml` file.

closes #110 