### PR TITLE
Add permissions to GitHub release action

### DIFF
--- a/.github/workflows/CD_release.yml
+++ b/.github/workflows/CD_release.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   github-release:
     name: GitHub Release
+    permissions:
+      contents: write
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Unfortunately, there is no more fine-grained control than that rather broad `contens: write` permission as seen [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token) and discussed [here](https://stackoverflow.com/questions/72383123/what-permissions-are-needed-for-github-actions-to-create-a-tag-and-release-for-a)