### PR TITLE
Linkchecker irgnore gnu

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -58,7 +58,7 @@ linkcheck_ignore = [
     # For now, let's avoid checking these
     "https://github.com/DeiC-HPC/cotainr",
     # Also ignore everything on the gnu domain via regex.
-    r'https://.*\.gnu\.org/.*'
+    r"https://.*\.gnu\.org/.*",
 ]
 linkcheck_anchors_ignore_for_url = [
     # Ignore GitHub issue comment anchors that apparently fails

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -57,6 +57,8 @@ linkcheck_ignore = [
     # We do have quite a lot of links to our own github repo
     # For now, let's avoid checking these
     "https://github.com/DeiC-HPC/cotainr",
+    # Also ignore everything on the gnu domain via regex.
+    r'https://.*\.gnu\.org/.*'
 ]
 linkcheck_anchors_ignore_for_url = [
     # Ignore GitHub issue comment anchors that apparently fails


### PR DESCRIPTION
Just added the gnu domain to the linkcheck_ignore as a regex. 