### PR TITLE
CI pull request triggers

### DIFF
--- a/.github/workflows/CI_pull_request.yml
+++ b/.github/workflows/CI_pull_request.yml
@@ -116,6 +116,7 @@ jobs:
           path: dist
 
   run-full-test-suite:
+    if: github.event.pull_request.draft == false
     needs: [prepare-for-build]
     name: Run full test suite
     runs-on: ${{ matrix.os.runs-on }}

--- a/.github/workflows/CI_pull_request.yml
+++ b/.github/workflows/CI_pull_request.yml
@@ -1,8 +1,14 @@
 name: CI on pull request
+
+# The test suite is triggered when opening, reopening or synchronizing a non-draft pull request
+# (The default triggers were identical but for both draft and non-draft pull requests)
+# Additionally, we trigger when a pull request is taken out from draft mode (ready_for_review)
+
 on:
   pull_request:
     branches:
       - main
+    types: [opened, reopened, synchronize, ready_for_review]
   schedule:
       - cron: '15 2 * * TUE'  # Also run the full test suite for PRs on the main branch every Tuesday night
   workflow_dispatch:  # allow for manually trigging the workflow
@@ -43,6 +49,7 @@ jobs:
           name: dist
           path: dist
   run-full-test-suite-x86:
+    if: github.event.pull_request.draft == false
     name: Run full test suite on x86
     runs-on: ${{ matrix.os }}
     strategy:
@@ -96,6 +103,7 @@ jobs:
             pytest_junit_out.xml
             htmlcov/*
   run-full-test-suite-ARM:
+    if: github.event.pull_request.draft == false
     name: Run full test suite ARM64
     runs-on: ${{ matrix.os }}
     strategy:

--- a/doc/development/test_suite_ci_cd.rst
+++ b/doc/development/test_suite_ci_cd.rst
@@ -87,6 +87,7 @@ The following CI `workflows <https://docs.github.com/en/actions/using-workflows/
   Runs the unit tests on pushes to all branches. Restricted to *stable* and *latest* Python versions.
   Lint and formatting checks (as described in the :ref:`style guide <style_guide>`) are also run and enforced.
 
+The test suite in the CI on Pull Requests is very thorough, and so it is only launched for pull requests that are not in draft mode. Additionally, it is launched the moment when a pull request is taken out of draft mode. On development where end-to-end and singularity integration testing are critical, the test suite should be run locally through the docker containers.
 
 Continuous Delivery (CD)
 ------------------------


### PR DESCRIPTION
The waiting time of the test suite is too long for active development on the full test matrix. With a test matrix with 60 jobs, and probably only 20 concurrent runners, a single test suite run will on average take about 3 x 5 min = 15 minutes. Additionally, with a large number of runners we risk getting denial of service on link checkers etc. which add on at least 5 more minutes but more likely more because it is a manual process. This is absolutely a problem on an active development branch where multiple commits could be pushed quicker than the jobs finish resulting in a queue. Such a queue affect all other developers as well.

Therefore we would like to use the full matrix in a more limited capacity. Currently the workflow is triggered on 3 GitHub "types" namely: `opened`, `synchronize` and `closed`. The killer is `synchronize` which can happen often in an active branch thus overwhelming the runners resulting in a long queue or requires manual labor to stop the runners.

This PR limits launching the full test matrix to non-draft pull requests, as well as the moment when a pull request is taken out of draft mode.

Related issue: #91 