### PR TITLE
Added the correct YYYY.MM.MICRO version tag-pattern to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [{include-group = "tests"}, {include-group = "lint"}, {include-group = "do
 
 [tool.hatch.version]
 source = "vcs"
-tag-pattern = '(?P<version>^20[0-9]{2}\.(0*[1-9]|10|11|12)\.(0|[1-9][0-9]*)$)' # cotainr YYYY.MM.MICRO version format (as well as wrong YYYY.0M.MICRO format)
+tag-pattern = '(?P<version>^20[0-9]{2}\.([1-9]|10|11|12)\.(0|[1-9][0-9]*)$)' # cotainr YYYY.MM.MICRO version format
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
This is a follow-up to #105 that restricts the `tag-pattern` key in the `tool.hatch.version` table in `pyproject.toml` to the correct YYYY.MM.MICRO version format.

This had to be a separate PR after the changes in #105 since we need a valid latest version tag (e.g. 2025.7.1) for hatch-vcs not to error out on this change. The previous release tag (2025.03.0) unfortunately used the wrong YYYY.0M.MICRO format.